### PR TITLE
Normalize /home activation, fix OG URL formatting, and enhance Playwright Chrome tests

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+# Install npm dependencies
+npm install
+
+# Install Playwright browsers
+npx playwright install

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "preview": "vite preview",
     "test": "playwright test",
     "test:ui": "playwright test --ui",
-    "test:chrome": "playwright test --project=chromium-desktop chromium-mobile",
+    "test:chrome": "playwright test --project=chromium-desktop --project=chromium-mobile",
     "copy-src": "mkdir -p dist/src && cp -r src/* dist/src/",
     "copy-ffmpeg-files": "mkdir -p dist/ffmpeg && curl -L -o dist/ffmpeg/ffmpeg-core.js https://cdn.jsdelivr.net/npm/@ffmpeg/core@0.12.6/dist/esm/ffmpeg-core.js && curl -L -o dist/ffmpeg/ffmpeg-core.wasm https://cdn.jsdelivr.net/npm/@ffmpeg/core@0.12.6/dist/esm/ffmpeg-core.wasm && curl -L -o dist/ffmpeg/ffmpeg-core.worker.js https://cdn.jsdelivr.net/npm/@ffmpeg/core@0.12.6/dist/esm/ffmpeg-core.worker.js"
   },

--- a/src/common/metadata.js
+++ b/src/common/metadata.js
@@ -225,7 +225,7 @@ export function generateMetaTags(path) {
     <meta property="og:title" content="${title}">
     <meta property="og:description" content="${description}">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://safewebtool.com${path === '/' ? '' : `/${path}`}">
+    <meta property="og:url" content="https://safewebtool.com${path === '/' ? '' : path}">
     <meta name="twitter:card" content="summary">
     <meta name="twitter:title" content="${title}">
     <meta name="twitter:description" content="${description}">

--- a/src/router.js
+++ b/src/router.js
@@ -22,7 +22,9 @@ function updateActiveNavigation(path) {
   });
   
   // Add active class to current path
-  const pathSegment = path === '/' ? '/' : `/${path.split('/')[1]}`;
+  const pathSegment = (path === '/' || path === '/home')
+    ? '/'
+    : `/${path.split('/')[1]}`;
   const activeLink = document.querySelector(`nav a[href="${pathSegment}"]`);
   if (activeLink) {
     activeLink.classList.add('active');

--- a/tests/all.spec.js
+++ b/tests/all.spec.js
@@ -11,6 +11,12 @@ test.describe('SafeWebTool Tests', () => {
     await expect(page.locator('header h1')).toContainText('SafeWebTool');
     await expect(page.locator('nav a[href="/"]')).toBeVisible();
   });
+
+  test('home alias route works', async ({ page }) => {
+    await page.goto('/home');
+    await expect(page.locator('.tool-container h1')).toContainText('Welcome');
+    await expect(page.locator('nav a[href="/"]')).toHaveClass(/active/);
+  });
   
   // Test dynamic tool loading across all categories
   test('dynamic tool loading across all categories', async ({ page }) => {


### PR DESCRIPTION
- Normalized handling of the /home path so it activates the Home link just like /
- Fixed the Open Graph URL to avoid double slashes and use the provided path directly
- Updated the Chrome test command to specify both Playwright projects correctly
- Added a new Playwright test verifying that the /home route displays the welcome content and activates the Home link