### PR TITLE
Revamp routing and harden video tools for v1.0.8

### DIFF
--- a/index.html
+++ b/index.html
@@ -257,7 +257,7 @@
                     <img src="/src/assets/logo.svg" alt="SafeWebTool" class="h-6 w-6 mr-2" loading="lazy" decoding="async">
                     <p>© Dr. Ratheesh Kalarot</p>
                     <span class="mx-2">|</span>
-                    <span class="version">Version: 1.0.7</span>
+                    <span class="version">Version: 1.0.8</span>
                 </div>
                 <div class="mt-4 md:mt-0 flex space-x-4 text-sm">
                     <a href="https://scholar.google.co.nz/citations?user=BuKGWPEAAAAJ&hl=en" target="_blank" rel="noopener" class="text-gray-600 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400">Google Scholar</a>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "safewebtool",
-  "version": "1.0.6",
+  "version": "1.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "safewebtool",
-      "version": "1.0.6",
+      "version": "1.0.8",
       "dependencies": {
         "@ffmpeg/core": "^0.12.10",
         "@ffmpeg/ffmpeg": "^0.12.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safewebtool",
-  "version": "1.0.6",
+  "version": "1.0.8",
   "description": "SafeWebTool - A collection of browser-based tools for video, image, and text processing",
   "type": "module",
   "scripts": {

--- a/src/common/base.js
+++ b/src/common/base.js
@@ -3,6 +3,7 @@
  */
 import { addLog, updateProgress, showLogs, formatFileSize } from './utils.js';
 import { footerManager } from './footer-manager.js';
+import { initFileUpload as initSharedFileUpload } from './fileUpload.js';
 
 export class Tool {
   /**
@@ -68,6 +69,9 @@ export class Tool {
     
     // Tool-specific initialization
     await this.setup();
+
+    // Mark the rendered tool UI as interactive for tests and diagnostics.
+    document.querySelector('.tool-container')?.setAttribute('data-tool-ready', 'true');
     
     // Mark as initialized
     this.initialized = true;
@@ -186,25 +190,23 @@ export class Tool {
       return;
     }
     
-    import('./fileUpload.js').then(module => {
-      module.initFileUpload({
-        dropZoneId: dropZone.id,
-        fileInputId: fileInput.id,
-        acceptTypes: options.acceptTypes || '*/*',
-        onFileSelected: (file) => {
-          this.inputFile = file;
-          
-          // Enable process button if exists
-          if (this.elements.processBtn) {
-            this.elements.processBtn.disabled = false;
-          }
-          
-          // Call user's onFileSelected handler if provided
-          if (options.onFileSelected) {
-            options.onFileSelected(file);
-          }
+    initSharedFileUpload({
+      dropZoneId: dropZone.id,
+      fileInputId: fileInput.id,
+      acceptTypes: options.acceptTypes || '*/*',
+      onFileSelected: (file) => {
+        this.inputFile = file;
+        
+        // Enable process button if exists
+        if (this.elements.processBtn) {
+          this.elements.processBtn.disabled = false;
         }
-      });
+        
+        // Call user's onFileSelected handler if provided
+        if (options.onFileSelected) {
+          options.onFileSelected(file);
+        }
+      }
     });
   }
   

--- a/src/common/fileUpload.js
+++ b/src/common/fileUpload.js
@@ -21,7 +21,6 @@ export function initFileUpload(options) {
   // Get elements
   const dropZone = document.getElementById(dropZoneId);
   const fileInput = document.getElementById(fileInputId);
-  const fileSelectBtn = dropZone ? dropZone.querySelector('.file-select-btn') : null;
   
   if (!dropZone || !fileInput) {
     console.error(`Could not find elements: dropZone=${!!dropZone}, fileInput=${!!fileInput}`);
@@ -73,12 +72,20 @@ export function initFileUpload(options) {
   
   // Click handler for select button
   function handleSelectClick(e) {
+    const selectBtn = e.target.closest('.file-select-btn');
+    if (!selectBtn || !dropZone.contains(selectBtn)) return;
     e.stopPropagation();
-    fileInput.click();
+
+    const currentFileInput = document.getElementById(fileInputId);
+    if (currentFileInput) {
+      currentFileInput.click();
+    }
   }
   
   // Change handler for file input
   function handleFileInputChange(e) {
+    const target = e.target;
+    if (!target || target.id !== fileInputId) return;
     const file = e.target.files[0];
     if (file) handleFile(file);
   }
@@ -88,12 +95,9 @@ export function initFileUpload(options) {
   dropZone.addEventListener('dragleave', handleDragLeave);
   dropZone.addEventListener('drop', handleDrop);
   
-  // Add click handler only to the button
-  if (fileSelectBtn) {
-    fileSelectBtn.addEventListener('click', handleSelectClick);
-  }
-  
-  fileInput.addEventListener('change', handleFileInputChange);
+  // Delegated handlers survive tools that replace dropZone innerHTML after setup.
+  dropZone.addEventListener('click', handleSelectClick);
+  dropZone.addEventListener('change', handleFileInputChange);
   
   // Return cleanup function
   return function cleanup() {
@@ -101,10 +105,7 @@ export function initFileUpload(options) {
     dropZone.removeEventListener('dragleave', handleDragLeave);
     dropZone.removeEventListener('drop', handleDrop);
     
-    if (fileSelectBtn) {
-      fileSelectBtn.removeEventListener('click', handleSelectClick);
-    }
-    
-    fileInput.removeEventListener('change', handleFileInputChange);
+    dropZone.removeEventListener('click', handleSelectClick);
+    dropZone.removeEventListener('change', handleFileInputChange);
   };
-} 
+}

--- a/src/common/page-renderers.js
+++ b/src/common/page-renderers.js
@@ -1,0 +1,63 @@
+import { listToolsForCategory } from './tool-registry.js';
+
+export function renderCategoryPage(categoryConfig, categoryId) {
+  return `
+    <div class="container mx-auto px-4 py-8">
+      <div class="divide-y divide-gray-200 dark:divide-gray-600 overflow-hidden rounded-lg bg-white dark:bg-gray-800 shadow-sm mb-8 transition-colors">
+        <div class="px-4 py-5 sm:px-6">
+          <h1 class="text-4xl font-bold text-slate-800 dark:text-slate-100">${categoryConfig.name}</h1>
+          <p class="text-lg text-slate-600 dark:text-slate-300 mt-2">${categoryConfig.description}</p>
+        </div>
+        <div class="px-4 py-5 sm:p-6" itemscope itemtype="https://schema.org/ItemList">
+          <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+            ${listToolsForCategory(categoryId).map(([path, tool], index) => `
+              <a href="/${path}" class="bg-slate-50 dark:bg-gray-700 rounded-lg border border-slate-200 dark:border-gray-600 p-5 flex flex-col gap-2 hover:bg-white dark:hover:bg-gray-600 hover:shadow-md hover:border-slate-300 dark:hover:border-gray-500 transition-all duration-200" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+                <meta itemprop="position" content="${index + 1}">
+                <div class="text-3xl mb-1">${tool.icon}</div>
+                <h3 class="text-lg font-semibold text-slate-700 dark:text-slate-200" itemprop="name">${tool.name}</h3>
+                <p class="text-sm text-slate-500 dark:text-slate-400 flex-grow" itemprop="description">${tool.description}</p>
+              </a>
+            `).join('')}
+          </div>
+        </div>
+      </div>
+    </div>
+  `;
+}
+
+export function renderToolPageShell(toolInfo) {
+  return `
+    <div class="tool-page container mx-auto px-4 py-8" itemscope itemtype="https://schema.org/SoftwareApplication">
+      <meta itemprop="applicationCategory" content="WebApplication">
+      <meta itemprop="offers" itemscope itemtype="https://schema.org/Offer">
+      <meta itemprop="price" content="0">
+      <meta itemprop="priceCurrency" content="USD">
+      <div class="divide-y divide-gray-200 dark:divide-gray-600 overflow-hidden rounded-lg bg-white dark:bg-gray-800 shadow-sm transition-colors">
+        <div class="px-4 py-5 sm:px-6">
+          <h1 class="text-3xl font-semibold text-slate-800 dark:text-slate-100">${toolInfo.name}</h1>
+          <p class="text-slate-600 dark:text-slate-300 leading-relaxed mt-2">${toolInfo.description || ''}</p>
+        </div>
+        <div class="px-4 py-5 sm:p-6">
+          <div class="tool-content-area"></div>
+        </div>
+      </div>
+    </div>
+  `;
+}
+
+export function createFFmpegLoadingElement() {
+  const loadingEl = document.createElement('div');
+  loadingEl.id = 'ffmpeg-loading';
+  loadingEl.style.textAlign = 'center';
+  loadingEl.style.padding = '20px';
+  loadingEl.innerHTML = `
+    <div class="loading-ffmpeg">
+      <p>Loading FFmpeg components...</p>
+      <div class="progress">
+        <div class="progress-fill"></div>
+      </div>
+    </div>
+  `;
+  return loadingEl;
+}
+

--- a/src/common/tool-registry.js
+++ b/src/common/tool-registry.js
@@ -1,0 +1,80 @@
+import { categories, tools } from './metadata.js';
+
+// Vite discovers all tool modules at build time; adding a new tool file in a category
+// is enough for it to become loadable by the router.
+const toolModuleLoaders = import.meta.glob('../(video|image|text|ml)/*.js');
+
+function normalizePath(path = '/') {
+  const withoutQuery = path.split('?')[0].split('#')[0] || '/';
+  if (withoutQuery === '') return '/';
+  return withoutQuery.startsWith('/') ? withoutQuery : `/${withoutQuery}`;
+}
+
+function buildFallbackTool(categoryId, toolId) {
+  return {
+    id: toolId,
+    category: categoryId,
+    name: toolId.charAt(0).toUpperCase() + toolId.slice(1),
+    description: ''
+  };
+}
+
+/**
+ * Return a normalized route descriptor for a path.
+ * This is the single source of truth for route parsing.
+ * @param {string} path
+ */
+export function resolveAppRoute(path) {
+  const normalizedPath = normalizePath(path);
+  const segments = normalizedPath.split('/').filter(Boolean);
+
+  if (normalizedPath === '/sitemap.xml') {
+    return { kind: 'sitemap', path: normalizedPath, segments };
+  }
+
+  if (normalizedPath === '/' || normalizedPath === '/home') {
+    return { kind: 'home', path: normalizedPath, segments };
+  }
+
+  if (segments.length === 0) {
+    return { kind: 'home', path: '/', segments: [] };
+  }
+
+  const [categoryId, toolId] = segments;
+  const category = categories[categoryId];
+  if (!category) {
+    return { kind: 'not-found', path: normalizedPath, segments };
+  }
+
+  if (!toolId) {
+    return { kind: 'category', path: normalizedPath, segments, categoryId, category };
+  }
+
+  const toolPath = `${categoryId}/${toolId}`;
+  return {
+    kind: 'tool',
+    path: normalizedPath,
+    segments,
+    categoryId,
+    toolId,
+    toolPath,
+    category,
+    tool: tools[toolPath] || buildFallbackTool(categoryId, toolId)
+  };
+}
+
+export function listToolsForCategory(categoryId) {
+  return Object.entries(tools).filter(([path]) => path.startsWith(`${categoryId}/`));
+}
+
+export async function loadToolModule(categoryId, toolId) {
+  const modulePath = `../${categoryId}/${toolId}.js`;
+
+  if (toolModuleLoaders[modulePath]) {
+    return toolModuleLoaders[modulePath]();
+  }
+
+  // Fallback helps in dev if glob pattern misses a path.
+  return import(/* @vite-ignore */ `../${categoryId}/${toolId}.js`);
+}
+

--- a/src/router.js
+++ b/src/router.js
@@ -1,368 +1,183 @@
-import { 
-  generateMetaTags, 
+import {
+  generateMetaTags,
   generateStructuredData,
-  categories,
-  tools,
-  getToolMetadata,
-  getCategoryMetadata,
   getWelcomeContent,
-  getToolTemplate,
   get404Template,
   getErrorTemplate
 } from './common/metadata.js';
 import { footerManager } from './common/footer-manager.js';
+import { createFFmpegLoadingElement, renderCategoryPage, renderToolPageShell } from './common/page-renderers.js';
+import { loadToolModule, resolveAppRoute } from './common/tool-registry.js';
 
-// Eagerly discover all tool modules
-const toolModules = import.meta.glob('./(video|image|text|ml)/*.js');
+let navigationToken = 0;
+
+function delay(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function isHomePath(path) {
+  return path === '/' || path === '/home';
+}
 
 /**
- * Updates the active class on navigation links
- * @param {string} path - The current URL path
+ * Updates the active class on navigation links.
+ * @param {string} path
  */
 function updateActiveNavigation(path) {
-  // Remove active class from all nav links
-  document.querySelectorAll('nav a').forEach(link => {
-    link.classList.remove('active');
-  });
-  
-  // Add active class to current path
-  const pathSegment = (path === '/' || path === '/home')
-    ? '/'
-    : `/${path.split('/')[1]}`;
+  document.querySelectorAll('nav a').forEach(link => link.classList.remove('active'));
+
+  const pathSegment = isHomePath(path) ? '/' : `/${path.split('/')[1]}`;
   const activeLink = document.querySelector(`nav a[href="${pathSegment}"]`);
-  if (activeLink) {
-    activeLink.classList.add('active');
-  }
+  if (activeLink) activeLink.classList.add('active');
 }
 
-/**
- * Find a tool based on the path
- * @param {string} path - The URL path
- * @returns {Object|null} The tool data or null if not found
- */
-function findTool(path) {
-  // Parse the path to extract category and tool ID
-  const pathParts = path.split('/').filter(part => part);
-  if (pathParts.length < 1) return null;
-  
-  const category = pathParts[0];
-  const toolId = pathParts.length > 1 ? pathParts[1] : null;
-  
-  // Get the category metadata
-  const categoryConfig = categories[category];
-  if (!categoryConfig) return null;
-  
-  // If no specific tool requested, return the category
-  if (!toolId) return { category: categoryConfig, type: 'category', id: category };
-  
-  // Find the specific tool in metadata
-  const toolPath = `${category}/${toolId}`;
-  const tool = tools[toolPath];
-  
-  // Even if tool metadata is missing, return a basic tool object if the category is valid
-  // This ensures tools without complete metadata still work
-  return { 
-    category: categoryConfig, 
-    tool: tool || { 
-      id: toolId,
-      category,
-      name: toolId.charAt(0).toUpperCase() + toolId.slice(1),
-      description: ''
-    }, 
-    type: 'tool', 
-    id: category,
-    path: toolPath
-  };
-}
-
-/**
- * Generate content for a category page
- * @param {Object} categoryConfig - The category configuration
- * @param {string} categoryId - The category ID
- * @returns {string} HTML for the category page
- */
-function generateCategoryContent(categoryConfig, categoryId) {
-  return `
-    <div class="container mx-auto px-4 py-8">
-      <!-- Category Header Card -->
-      <div class="divide-y divide-gray-200 dark:divide-gray-600 overflow-hidden rounded-lg bg-white dark:bg-gray-800 shadow-sm mb-8 transition-colors">
-        <div class="px-4 py-5 sm:px-6">
-          <h1 class="text-4xl font-bold text-slate-800 dark:text-slate-100">${categoryConfig.name}</h1>
-          <p class="text-lg text-slate-600 dark:text-slate-300 mt-2">${categoryConfig.description}</p>
-        </div>
-        <div class="px-4 py-5 sm:p-6" itemscope itemtype="https://schema.org/ItemList">
-          <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-            ${Object.entries(tools)
-              .filter(([path]) => path.startsWith(categoryId + '/'))
-              .map(([path, tool], index) => {
-                return `
-                  <a href="/${path}" class="bg-slate-50 dark:bg-gray-700 rounded-lg border border-slate-200 dark:border-gray-600 p-5 flex flex-col gap-2 hover:bg-white dark:hover:bg-gray-600 hover:shadow-md hover:border-slate-300 dark:hover:border-gray-500 transition-all duration-200" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
-                    <meta itemprop="position" content="${index + 1}">
-                    <div class="text-3xl mb-1">${tool.icon}</div>
-                    <h3 class="text-lg font-semibold text-slate-700 dark:text-slate-200" itemprop="name">${tool.name}</h3>
-                    <p class="text-sm text-slate-500 dark:text-slate-400 flex-grow" itemprop="description">${tool.description}</p>
-                  </a>
-                `;
-              }).join('')}
-          </div>
-        </div>
-      </div>
-    </div>
-  `;
-}
-
-/**
- * Initialize collapsible sections on the home page
- */
 function initializeCollapsibleSections() {
   const toggles = document.querySelectorAll('.category-toggle');
-  
-  // Set initial state
+
   document.querySelectorAll('.category-content').forEach(content => {
-    content.style.maxHeight = content.scrollHeight + 'px';
+    content.style.maxHeight = `${content.scrollHeight}px`;
   });
-  
+
   toggles.forEach(toggle => {
-    toggle.addEventListener('click', function() {
+    toggle.addEventListener('click', function () {
       const categoryId = this.getAttribute('data-category');
-      const content = document.querySelector('[data-category-content="' + categoryId + '"]');
+      const content = document.querySelector(`[data-category-content="${categoryId}"]`);
       const chevron = this.querySelector('svg');
-      
-      if (content && chevron) {
-        const isCollapsed = content.style.maxHeight === '0px';
-        
-        if (isCollapsed) {
-          // Expand
-          content.style.maxHeight = content.scrollHeight + 'px';
-          content.style.opacity = '1';
-          chevron.classList.remove('-rotate-90');
-        } else {
-          // Collapse
-          content.style.maxHeight = '0px';
-          content.style.opacity = '0';
-          chevron.classList.add('-rotate-90');
-        }
-      }
+
+      if (!content || !chevron) return;
+
+      const isCollapsed = content.style.maxHeight === '0px';
+      content.style.maxHeight = isCollapsed ? `${content.scrollHeight}px` : '0px';
+      content.style.opacity = isCollapsed ? '1' : '0';
+      chevron.classList.toggle('-rotate-90', !isCollapsed);
     });
   });
 }
 
-/**
- * Main route handler
- * @param {string} path - The URL path
- */
-export async function handleRoute(path) {
-  // Restore original footer when navigating (tools can override it later)
-  footerManager.restoreOriginalFooter();
-  
-  // Update active navigation
-  updateActiveNavigation(path);
-  
-  // Handle sitemap.xml requests
-  if (path === '/sitemap.xml') {
-    import('./common/sitemap.js').then(({ serveSitemap }) => {
-      document.documentElement.innerHTML = `
-        <pre style="word-wrap: break-word; white-space: pre-wrap;">
-          ${serveSitemap()}
-        </pre>
-      `;
-      if (document.contentType) {
-        document.contentType = 'application/xml';
-      }
-    });
-    return;
-  }
-
-  const main = document.querySelector('main');
-  if (!main) return;
-  main.innerHTML = '';
-
-  let content = '';
-  
-  // Update metadata for SEO
-  updateMetadata(path);
-  
-  // Handle root path
-  if (path === '/' || path === '/home') {
-    content = getWelcomeContent();
-  } else {
-    // Find the requested tool or category
-    const result = findTool(path);
-    
-    if (!result) {
-      // 404 page
-      content = get404Template();
-    } else if (result.type === 'category') {
-      // Category page (e.g., /video)
-      content = generateCategoryContent(result.category, result.id);
-    } else {
-      // Specific tool page (e.g., /video/resize)
-      const [category, toolId] = result.path.split('/');
-      
-      // Enhance template with SEO content and tool information
-      const toolInfo = result.tool;
-      content = `
-        <div class="tool-page container mx-auto px-4 py-8" itemscope itemtype="https://schema.org/SoftwareApplication">
-          <meta itemprop="applicationCategory" content="WebApplication">
-          <meta itemprop="offers" itemscope itemtype="https://schema.org/Offer">
-          <meta itemprop="price" content="0">
-          <meta itemprop="priceCurrency" content="USD">
-          
-          <div class="divide-y divide-gray-200 dark:divide-gray-600 overflow-hidden rounded-lg bg-white dark:bg-gray-800 shadow-sm transition-colors">
-            <div class="px-4 py-5 sm:px-6">
-              <h1 class="text-3xl font-semibold text-slate-800 dark:text-slate-100">${toolInfo.name}</h1>
-              <p class="text-slate-600 dark:text-slate-300 leading-relaxed mt-2">${toolInfo.description || ''}</p>
-            </div>
-            <div class="px-4 py-5 sm:p-6">
-              <div class="tool-content-area"></div>
-            </div>
-          </div>
-        </div>
-      `;
+function renderSitemap() {
+  import('./common/sitemap.js').then(({ serveSitemap }) => {
+    document.documentElement.innerHTML = `
+      <pre style="word-wrap: break-word; white-space: pre-wrap;">
+        ${serveSitemap()}
+      </pre>
+    `;
+    if (document.contentType) {
+      document.contentType = 'application/xml';
     }
-  }
-  
-  // Update page content
-  main.innerHTML = content;
-  
-  // Initialize collapsible sections if on home page
-  if (path === '/' || path === '/home') {
-    setTimeout(() => {
-      initializeCollapsibleSections();
-    }, 50);
-  }
-  
-  // Initialize tool AFTER DOM elements are available
-  if (path !== '/' && path !== '/home') {
-    const result = findTool(path);
-    if (result && result.type === 'tool') {
-      try {
-        // Small delay to ensure DOM is fully updated
-        setTimeout(async () => {
-          try {
-            // Extract category and toolId from path
-            const [category, toolId] = result.path.split('/');
-            
-            // Preload common styles and utilities first
-            await import('./common/utils.js');
-            
-            // Check if this is a video tool that requires FFmpeg
-            const needsFFmpeg = (category === 'video');
-            
-            // Display loading indicator for FFmpeg tools
-            if (needsFFmpeg) {
-              const loadingHtml = `
-                <div class="loading-ffmpeg">
-                  <p>Loading FFmpeg components...</p>
-                  <div class="progress">
-                    <div class="progress-fill"></div>
-                  </div>
-                </div>
-              `;
-              const loadingEl = document.createElement('div');
-              loadingEl.innerHTML = loadingHtml;
-              loadingEl.style.textAlign = 'center';
-              loadingEl.style.padding = '20px';
-              loadingEl.id = 'ffmpeg-loading';
-              document.querySelector('.tool-content-area')?.appendChild(loadingEl);
-            }
-            
-            // Import directly from the current directory structure
-            let moduleImport;
-            try {
-              const modulePath = `./${category}/${toolId}.js`;
+  });
+}
 
-              if (toolModules[modulePath]) {
-                moduleImport = await toolModules[modulePath]();
-              } else {
-                console.error(`Module not found in import.meta.glob cache: ${modulePath}`);
-                // Attempt direct dynamic import as a fallback (might not work in prod if not analyzed)
-                try {
-                    moduleImport = await import(/* @vite-ignore */ modulePath);
-                    console.warn(`Loaded module ${modulePath} via fallback dynamic import.`);
-                } catch (fallbackError) {
-                    console.error(`Fallback dynamic import for ${modulePath} also failed:`, fallbackError);
-                    throw new Error(`Module ${modulePath} not found.`);
-                }
-              }
-            } catch (error) {
-              console.error(`Failed to load tool module: ${error.message}`);
-              main.innerHTML = getErrorTemplate(
-                'Error Loading Tool', 
-                'The requested tool could not be loaded.', 
-                error.message
-              );
-              return;
-            }
-            
-            // Remove loading indicator if it exists
-            document.getElementById('ffmpeg-loading')?.remove();
-            
-            // Call the initialization function
-            if (moduleImport && moduleImport.initTool) {
-              if (moduleImport.template) {
-                const toolContentArea = document.querySelector('.tool-content-area');
-                if (toolContentArea) {
-                  // Simply inject the entire template
-                  toolContentArea.innerHTML = moduleImport.template;
-                } else {
-                  console.error('CRITICAL: .tool-content-area not found in .tool-page!');
-                }
-              }
-              moduleImport.initTool();
-            } else {
-              main.innerHTML = getErrorTemplate(
-                'Error Loading Tool', 
-                `The tool "${toolId}" could not be initialized.`,
-                `Init function 'initTool' not found in module for ${category}/${toolId}`
-              );
-            }
-          } catch (error) {
-            console.error('Error initializing tool:', error);
-          }
-        }, 100);
-      } catch (error) {
-        console.error('Error initializing tool:', error);
-      }
-    }
+function renderRouteShell(route) {
+  switch (route.kind) {
+    case 'home':
+      return getWelcomeContent();
+    case 'category':
+      return renderCategoryPage(route.category, route.categoryId);
+    case 'tool':
+      return renderToolPageShell(route.tool);
+    case 'not-found':
+      return get404Template();
+    default:
+      return '';
   }
 }
 
-/**
- * Update page metadata for SEO
- * @param {string} path - Current path
- */
+function injectToolTemplate(moduleImport) {
+  if (!moduleImport?.template) return true;
+
+  const toolContentArea = document.querySelector('.tool-content-area');
+  if (!toolContentArea) {
+    console.error('CRITICAL: .tool-content-area not found in .tool-page!');
+    return false;
+  }
+
+  toolContentArea.innerHTML = moduleImport.template;
+  return true;
+}
+
+async function initializeToolRoute(route, main, tokenAtStart) {
+  if (route.kind !== 'tool') return;
+
+  await delay(50);
+  if (tokenAtStart !== navigationToken) return;
+
+  try {
+    await import('./common/utils.js');
+
+    if (route.categoryId === 'video') {
+      document.querySelector('.tool-content-area')?.appendChild(createFFmpegLoadingElement());
+    }
+
+    let moduleImport;
+    try {
+      moduleImport = await loadToolModule(route.categoryId, route.toolId);
+    } catch (error) {
+      console.error(`Failed to load tool module ${route.toolPath}:`, error);
+      if (tokenAtStart !== navigationToken) return;
+      main.innerHTML = getErrorTemplate(
+        'Error Loading Tool',
+        'The requested tool could not be loaded.',
+        error.message
+      );
+      return;
+    }
+
+    if (tokenAtStart !== navigationToken) return;
+
+    document.getElementById('ffmpeg-loading')?.remove();
+
+    if (!moduleImport?.initTool) {
+      main.innerHTML = getErrorTemplate(
+        'Error Loading Tool',
+        `The tool "${route.toolId}" could not be initialized.`,
+        `Init function 'initTool' not found in module for ${route.toolPath}`
+      );
+      return;
+    }
+
+    if (!injectToolTemplate(moduleImport)) {
+      main.innerHTML = getErrorTemplate(
+        'Error Loading Tool',
+        `The tool "${route.toolId}" could not be rendered.`,
+        'Missing .tool-content-area container in tool page shell'
+      );
+      return;
+    }
+
+    moduleImport.initTool();
+  } catch (error) {
+    console.error('Error initializing tool:', error);
+    if (tokenAtStart !== navigationToken) return;
+    main.innerHTML = getErrorTemplate(
+      'Error Loading Tool',
+      'Unexpected error while initializing the tool.',
+      error.message
+    );
+  }
+}
+
 function updateMetadata(path) {
-  // Remove existing meta tags we might have added
   document.querySelectorAll('meta[data-dynamic="true"]').forEach(el => el.remove());
   document.querySelectorAll('script[type="application/ld+json"]').forEach(el => el.remove());
-  
-  // Get head element
+
   const head = document.head;
-  
-  // Add new meta tags
+
   const metaContainer = document.createElement('div');
   metaContainer.innerHTML = generateMetaTags(path);
-  
-  // Add each node to head
   Array.from(metaContainer.children).forEach(node => {
     node.setAttribute('data-dynamic', 'true');
     head.appendChild(node);
   });
-  
-  // Add structured data for tool pages
-  const parts = path.split('/').filter(p => p);
-  if (parts.length === 2) {
+
+  const route = resolveAppRoute(path);
+  if (route.kind === 'tool') {
     const structuredDataContainer = document.createElement('div');
-    structuredDataContainer.innerHTML = generateStructuredData(`${parts[0]}/${parts[1]}`);
-    
-    // Add structured data script to head
+    structuredDataContainer.innerHTML = generateStructuredData(route.toolPath);
     Array.from(structuredDataContainer.children).forEach(node => {
       head.appendChild(node);
     });
   }
-  
-  // Add sitemap link for SEO
+
   const sitemapLink = document.createElement('link');
   sitemapLink.rel = 'sitemap';
   sitemapLink.type = 'application/xml';
@@ -370,3 +185,37 @@ function updateMetadata(path) {
   sitemapLink.setAttribute('data-dynamic', 'true');
   head.appendChild(sitemapLink);
 }
+
+/**
+ * Main route handler
+ * @param {string} path
+ */
+export async function handleRoute(path) {
+  const route = resolveAppRoute(path);
+  const token = ++navigationToken;
+
+  footerManager.restoreOriginalFooter();
+  updateActiveNavigation(route.path);
+
+  if (route.kind === 'sitemap') {
+    renderSitemap();
+    return;
+  }
+
+  const main = document.querySelector('main');
+  if (!main) return;
+
+  updateMetadata(route.path);
+  main.innerHTML = renderRouteShell(route);
+
+  if (route.kind === 'home') {
+    setTimeout(() => {
+      if (token !== navigationToken) return;
+      initializeCollapsibleSections();
+    }, 50);
+    return;
+  }
+
+  await initializeToolRoute(route, main, token);
+}
+

--- a/src/video/ffmpeg-utils.js
+++ b/src/video/ffmpeg-utils.js
@@ -249,12 +249,95 @@ export async function readOutputFile(ffmpeg, fileName) {
 export async function executeFFmpeg(ffmpeg, args) {
   try {
     addLog(`Executing FFmpeg command: ffmpeg ${args.join(' ')}`, 'info');
-    await ffmpeg.exec(args);
+    const exitCode = await ffmpeg.exec(args);
+    if (exitCode !== 0) {
+      throw new Error(`FFmpeg exited with code ${exitCode}`);
+    }
     addLog('FFmpeg command completed successfully', 'success');
   } catch (error) {
-    addLog(`FFmpeg command failed: ${error.message}`, 'error');
-    throw error;
+    const normalizedError = normalizeFFmpegError(error);
+    addLog(`FFmpeg command failed: ${normalizedError.message}`, 'error');
+    throw normalizedError;
   }
+}
+
+function normalizeFFmpegError(error) {
+  if (error instanceof Error && error.message) return error;
+
+  if (typeof error === 'string' && error.trim()) {
+    return new Error(error);
+  }
+
+  if (error && typeof error === 'object') {
+    const message = error.message || error.reason || error.name;
+    if (message) return new Error(String(message));
+  }
+
+  return new Error('FFmpeg aborted while processing the video. Try MP4 output or lower settings.');
+}
+
+export function getX264EncodeArgs({ quality = 'medium', bitrateKbps = 2000, audio = true, faststart = true } = {}) {
+  const preset =
+    quality === 'high' ? 'medium' :
+    quality === 'low' ? 'veryfast' :
+    'fast';
+
+  const crf =
+    quality === 'high' ? '20' :
+    quality === 'low' ? '29' :
+    '24';
+
+  const args = [
+    '-c:v', 'libx264',
+    '-preset', preset,
+    '-crf', crf,
+    '-pix_fmt', 'yuv420p',
+    '-b:v', `${bitrateKbps}k`,
+    '-maxrate', `${bitrateKbps}k`,
+    '-bufsize', `${Math.max(1000, bitrateKbps * 2)}k`
+  ];
+
+  if (faststart) {
+    args.push('-movflags', '+faststart');
+  }
+
+  if (audio) {
+    args.push('-c:a', 'aac', '-b:a', '96k');
+  } else {
+    args.push('-an');
+  }
+
+  return args;
+}
+
+export function getFastWebMEncodeArgs({ quality = 'medium', bitrateKbps = 1200, audio = true } = {}) {
+  // VP8 is significantly faster than VP9 in ffmpeg.wasm and is broadly compatible.
+  const deadline =
+    quality === 'high' ? 'good' :
+    quality === 'low' ? 'realtime' :
+    'realtime';
+
+  const cpuUsed =
+    quality === 'high' ? '4' :
+    quality === 'low' ? '8' :
+    '6';
+
+  const args = [
+    '-c:v', 'libvpx',
+    '-b:v', `${bitrateKbps}k`,
+    '-deadline', deadline,
+    '-cpu-used', cpuUsed,
+    '-auto-alt-ref', '0',
+    '-pix_fmt', 'yuv420p'
+  ];
+
+  if (audio) {
+    args.push('-c:a', 'libopus', '-b:a', '96k');
+  } else {
+    args.push('-an');
+  }
+
+  return args;
 }
 
 /**

--- a/src/video/gif.js
+++ b/src/video/gif.js
@@ -115,7 +115,9 @@ class VideoGifTool extends Tool {
       startTime: 'startTime',
       duration: 'duration',
       progress: 'progress',
-      downloadContainer: 'downloadContainer'
+      downloadContainer: 'downloadContainer',
+      logHeader: 'logHeader',
+      logContent: 'logContent'
     };
   }
 
@@ -127,7 +129,7 @@ class VideoGifTool extends Tool {
         this.log(`Loaded video: ${file.name} (${formatFileSize(file.size)})`, 'info');
         
         // Get video dimensions when metadata is loaded
-        this.elements.inputVideo.onloadedmetadata = () => {
+        const applyMetadata = () => {
           this.videoAspectRatio = this.elements.inputVideo.videoWidth / this.elements.inputVideo.videoHeight;
           
           // Set default width maintaining aspect ratio
@@ -136,14 +138,22 @@ class VideoGifTool extends Tool {
             this.updateHeight();
           }
         };
+        this.elements.inputVideo.onloadedmetadata = applyMetadata;
+        if (this.elements.inputVideo.readyState >= 1 && this.elements.inputVideo.videoWidth > 0) {
+          applyMetadata();
+        }
         
         // Update duration field based on video length
-        this.elements.inputVideo.onloadeddata = () => {
+        const applyLoadedData = () => {
           if (this.elements.duration.value == 5.0) {
             const videoLength = this.elements.inputVideo.duration;
             this.elements.duration.value = videoLength < 5 ? videoLength.toFixed(1) : 5.0;
           }
         };
+        this.elements.inputVideo.onloadeddata = applyLoadedData;
+        if (this.elements.inputVideo.readyState >= 2 && Number.isFinite(this.elements.inputVideo.duration)) {
+          applyLoadedData();
+        }
       }
     });
 

--- a/src/video/mp4.js
+++ b/src/video/mp4.js
@@ -3,7 +3,14 @@
  */
 import { Tool } from '../common/base.js';
 import { formatFileSize } from '../common/utils.js';
-import { loadFFmpeg, writeInputFile, readOutputFile, executeFFmpeg, getExtension } from './ffmpeg-utils.js';
+import {
+  loadFFmpeg,
+  writeInputFile,
+  readOutputFile,
+  executeFFmpeg,
+  getExtension,
+  getX264EncodeArgs
+} from './ffmpeg-utils.js';
 
 // Video MP4 convert tool template
 export const template = `
@@ -95,6 +102,7 @@ class VideoMp4Tool extends Tool {
       quality: 'quality',
       bitrate: 'bitrate',
       progress: 'progress',
+      outputContainer: 'outputContainer',
       downloadContainer: 'downloadContainer',
       logHeader: 'logHeader',
       logContent: 'logContent'
@@ -155,17 +163,8 @@ class VideoMp4Tool extends Tool {
         ffmpegArgs.push('-vf', `scale=${scaleMap[resolution]}`);
       }
 
-      // x264 quality/preset similar to CloudConvert selectable quality
-      ffmpegArgs.push(
-        '-c:v', 'libx264',
-        '-preset', quality === 'high' ? 'slow' : quality === 'medium' ? 'medium' : 'fast',
-        '-b:v', `${targetKbps}k`,
-        '-maxrate', `${targetKbps}k`,
-        '-bufsize', `${targetKbps * 2}k`,
-        '-movflags', '+faststart',
-        '-c:a', 'aac',
-        '-b:a', '128k'
-      );
+      // Favor browser-wasm speed while keeping broad compatibility.
+      ffmpegArgs.push(...getX264EncodeArgs({ quality, bitrateKbps: targetKbps, audio: true, faststart: true }));
 
       ffmpegArgs.push('-y', outputFileName);
 
@@ -176,6 +175,10 @@ class VideoMp4Tool extends Tool {
       this.log('Reading output file...', 'info');
       const data = await readOutputFile(this.ffmpeg, outputFileName);
       const blob = new Blob([data], { type: 'video/mp4' });
+
+      if (this.elements.outputContainer) {
+        this.elements.outputContainer.style.display = 'block';
+      }
 
       this.displayOutputMedia(blob, 'outputVideo', 'converted_video.mp4', 'downloadContainer');
       this.updateProgress(100);
@@ -196,5 +199,3 @@ export function initTool() {
   });
   return tool.init();
 }
-
-

--- a/src/video/reencode.js
+++ b/src/video/reencode.js
@@ -3,7 +3,15 @@
  */
 import { Tool } from '../common/base.js';
 import { formatFileSize } from '../common/utils.js';
-import { loadFFmpeg, writeInputFile, readOutputFile, executeFFmpeg, getExtension } from './ffmpeg-utils.js';
+import {
+  loadFFmpeg,
+  writeInputFile,
+  readOutputFile,
+  executeFFmpeg,
+  getExtension,
+  getX264EncodeArgs,
+  getFastWebMEncodeArgs
+} from './ffmpeg-utils.js';
 
 // Video reencode tool template
 export const template = `
@@ -169,28 +177,11 @@ class VideoReencodeTool extends Tool {
       const ffmpegArgs = ['-i', inputFileName];
 
       if (format === 'mp4') {
-        ffmpegArgs.push(
-          '-c:v', 'libx264',
-          '-preset', quality === 'high' ? 'slow' : quality === 'medium' ? 'medium' : 'fast',
-          '-crf', quality === 'high' ? '18' : quality === 'medium' ? '23' : '28',
-          '-c:a', 'aac',
-          '-b:a', '128k'
-        );
+        ffmpegArgs.push(...getX264EncodeArgs({ quality, bitrateKbps: bitrate, audio: true, faststart: true }));
       } else if (format === 'webm') {
-        ffmpegArgs.push(
-          '-c:v', 'libvpx-vp9',
-          '-b:v', `${bitrate}k`,
-          '-deadline', quality === 'high' ? 'best' : quality === 'medium' ? 'good' : 'realtime',
-          '-c:a', 'libopus'
-        );
+        ffmpegArgs.push(...getFastWebMEncodeArgs({ quality, bitrateKbps: bitrate, audio: true }));
       } else if (format === 'mov') {
-        ffmpegArgs.push(
-          '-c:v', 'libx264',
-          '-preset', quality === 'high' ? 'slow' : quality === 'medium' ? 'medium' : 'fast',
-          '-crf', quality === 'high' ? '18' : quality === 'medium' ? '23' : '28',
-          '-c:a', 'aac',
-          '-b:a', '128k'
-        );
+        ffmpegArgs.push(...getX264EncodeArgs({ quality, bitrateKbps: bitrate, audio: true, faststart: false }));
       }
 
       ffmpegArgs.push(outputFileName);

--- a/src/video/resize.js
+++ b/src/video/resize.js
@@ -3,7 +3,16 @@
  */
 import { Tool } from '../common/base.js';
 import { formatFileSize } from '../common/utils.js';
-import { loadFFmpeg, getFFmpeg, writeInputFile, readOutputFile, executeFFmpeg, getExtension, cleanupFFmpeg } from './ffmpeg-utils.js';
+import {
+  loadFFmpeg,
+  getFFmpeg,
+  writeInputFile,
+  readOutputFile,
+  executeFFmpeg,
+  getExtension,
+  cleanupFFmpeg,
+  getX264EncodeArgs
+} from './ffmpeg-utils.js';
 
 // Video resize tool template
 export const template = `
@@ -102,9 +111,14 @@ class VideoResizeTool extends Tool {
     this.initFileUpload({
       acceptTypes: 'video/*',
       onFileSelected: (file) => {
+        this.handleVideoMetadata();
         this.displayPreview(file, 'inputVideo');
         this.log(`Loaded video: ${file.name} (${formatFileSize(file.size)})`, 'info');
-        this.handleVideoMetadata();
+
+        // Avoid deadlock if metadata is slow/missed: allow manual dimensions immediately.
+        this.enableInputs();
+        if (!this.elements.width.value) this.elements.width.value = 320;
+        if (!this.elements.height.value) this.elements.height.value = 180;
       }
     });
 
@@ -120,7 +134,7 @@ class VideoResizeTool extends Tool {
 
   handleVideoMetadata() {
     if (this.elements.inputVideo) {
-      this.elements.inputVideo.onloadedmetadata = () => {
+      const applyMetadata = () => {
         this.originalWidth = this.elements.inputVideo.videoWidth;
         this.originalHeight = this.elements.inputVideo.videoHeight;
         this.videoAspectRatio = this.originalWidth / this.originalHeight;
@@ -128,6 +142,12 @@ class VideoResizeTool extends Tool {
         this.enableInputs();
         this.setInitialValues();
       };
+
+      this.elements.inputVideo.onloadedmetadata = applyMetadata;
+
+      if (this.elements.inputVideo.readyState >= 1 && this.elements.inputVideo.videoWidth > 0) {
+        applyMetadata();
+      }
     }
   }
 
@@ -339,7 +359,7 @@ class VideoResizeTool extends Tool {
 
       const dimensions = this.calculateDimensions();
       const { width, height } = dimensions;
-      const quality = this.elements.quality ? this.elements.quality.value : 'medium';
+      const quality = this.elements.quality ? this.elements.quality.value : 'low';
 
       if (width <= 0 || height <= 0) {
         this.log('Please enter valid dimensions', 'error');
@@ -372,25 +392,41 @@ class VideoResizeTool extends Tool {
       }
 
       const inputFileName = 'input' + getExtension(file.name);
-      const outputFileName = 'output' + getExtension(file.name);
+      const outputFileName = 'output.mp4';
 
       this.log('Writing input file...', 'info');
       await writeInputFile(ffmpegInstance, inputFileName, file);
       this.updateProgress(30, 'Input file processed');
 
-      const scaleFilter = `scale=${width}:${height}:flags=lanczos`;
-      const qualityArgs = quality === 'high' ? ['-crf', '18'] :
-                         quality === 'medium' ? ['-crf', '23'] :
-                         ['-crf', '28'];
-
+      const scaleFilter = `scale=${width}:${height}:flags=fast_bilinear`;
       this.updateProgress(40, 'Starting resize...');
-      await executeFFmpeg(ffmpegInstance, [
-        '-i', inputFileName,
-        '-vf', scaleFilter,
-        ...qualityArgs,
-        '-preset', 'medium',
-        '-y', outputFileName
-      ]);
+      try {
+        await executeFFmpeg(ffmpegInstance, [
+          '-i', inputFileName,
+          '-vf', scaleFilter,
+          '-c:v', 'libx264',
+          '-preset', 'ultrafast',
+          '-crf', quality === 'high' ? '22' : quality === 'medium' ? '26' : '30',
+          '-pix_fmt', 'yuv420p',
+          '-c:a', 'copy',
+          '-movflags', '+faststart',
+          '-y', outputFileName
+        ]);
+      } catch (audioCopyError) {
+        this.log('Audio copy failed, retrying with AAC audio for compatibility...', 'info');
+        const encodeArgs = getX264EncodeArgs({
+          quality,
+          bitrateKbps: width >= 1280 ? 1600 : 800,
+          audio: true,
+          faststart: true
+        });
+        await executeFFmpeg(ffmpegInstance, [
+          '-i', inputFileName,
+          '-vf', scaleFilter,
+          ...encodeArgs,
+          '-y', outputFileName
+        ]);
+      }
       this.updateProgress(80, 'Resize complete');
 
       this.log('Reading output file...', 'info');
@@ -400,14 +436,14 @@ class VideoResizeTool extends Tool {
         throw new Error('Generated video is empty. Check video format or try different settings.');
       }
       
-      const blob = new Blob([data], { type: file.type });
+      const blob = new Blob([data], { type: 'video/mp4' });
       this.updateProgress(90, 'Preparing download...');
       
       if (this.elements.outputContainer) {
         this.elements.outputContainer.style.display = 'block';
       }
       
-      this.displayOutputMedia(blob, 'outputVideo', `video_${width}x${height}${getExtension(file.name)}`, 'downloadContainer');
+      this.displayOutputMedia(blob, 'outputVideo', `video_${width}x${height}.mp4`, 'downloadContainer');
       
       // Clean up the instance after processing
       try {

--- a/src/video/reverse.js
+++ b/src/video/reverse.js
@@ -3,7 +3,14 @@
  */
 import { Tool } from '../common/base.js';
 import { formatFileSize, formatTime } from '../common/utils.js';
-import { loadFFmpeg, writeInputFile, readOutputFile, executeFFmpeg, getExtension } from './ffmpeg-utils.js';
+import {
+  loadFFmpeg,
+  writeInputFile,
+  readOutputFile,
+  executeFFmpeg,
+  getExtension,
+  getX264EncodeArgs
+} from './ffmpeg-utils.js';
 
 // Video reverse tool template
 export const template = `
@@ -82,7 +89,7 @@ export const template = `
           </div>
         </div>
         <div class="flex items-center gap-3 p-3 bg-slate-50 dark:bg-gray-700 rounded-lg">
-          <input type="checkbox" id="removeAudio" class="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600">
+          <input type="checkbox" id="removeAudio" checked class="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600">
           <label for="removeAudio" class="text-sm font-medium text-slate-700 dark:text-slate-300">
             Remove audio (recommended for reversed videos)
           </label>
@@ -159,12 +166,9 @@ class VideoReverseTool extends Tool {
     this.initFileUpload({
       acceptTypes: 'video/*',
       onFileSelected: (file) => {
-        this.displayPreview(file, 'inputVideo');
-        this.log(`Loaded video: ${file.name} (${formatFileSize(file.size)})`, 'info');
-        
         // Get video duration when metadata is loaded
         if (this.elements.inputVideo) {
-          this.elements.inputVideo.onloadedmetadata = () => {
+          const applyMetadata = () => {
             this.videoDuration = this.elements.inputVideo.duration;
             
             // Enable inputs
@@ -182,6 +186,27 @@ class VideoReverseTool extends Tool {
             // Initialize the slider
             this.initSlider();
           };
+
+          this.elements.inputVideo.onloadedmetadata = applyMetadata;
+          if (this.elements.inputVideo.readyState >= 1 && Number.isFinite(this.elements.inputVideo.duration)) {
+            applyMetadata();
+          }
+        }
+
+        this.displayPreview(file, 'inputVideo');
+        this.log(`Loaded video: ${file.name} (${formatFileSize(file.size)})`, 'info');
+
+        // Avoid UI deadlock if metadata loading is delayed.
+        this.elements.startTime.disabled = false;
+        this.elements.endTime.disabled = false;
+        this.elements.processBtn.disabled = false;
+        this.elements.removeAudio.disabled = false;
+        if (!this.videoDuration || !Number.isFinite(this.videoDuration)) {
+          this.videoDuration = 1;
+          this.startTime = 0;
+          this.endTime = 1;
+          this.elements.startTime.value = '0:00';
+          this.elements.endTime.value = '0:01';
         }
       }
     });
@@ -391,7 +416,7 @@ class VideoReverseTool extends Tool {
       this.updateProgress(20);
 
       const inputFileName = 'input' + getExtension(file.name);
-      const outputFileName = 'output' + getExtension(file.name);
+      const outputFileName = 'output.mp4';
 
       this.log('Writing input file...', 'info');
       await writeInputFile(this.ffmpeg, inputFileName, file);
@@ -409,11 +434,12 @@ class VideoReverseTool extends Tool {
       ];
       
       if (shouldRemoveAudio) {
-        ffmpegArgs.push('-an'); // Remove audio
+        ffmpegArgs.push(...getX264EncodeArgs({ quality: 'medium', bitrateKbps: 1400, audio: false, faststart: true }));
         this.log('Removing audio from reversed video...', 'info');
       } else {
-        ffmpegArgs.push('-c:a', 'aac'); // Keep audio with AAC codec
-        this.log('Keeping audio in reversed video (may sound unusual)...', 'info');
+        ffmpegArgs.push('-af', 'areverse');
+        ffmpegArgs.push(...getX264EncodeArgs({ quality: 'medium', bitrateKbps: 1400, audio: true, faststart: true }));
+        this.log('Keeping and reversing audio (slower)...', 'info');
       }
       
       ffmpegArgs.push('-y', outputFileName);
@@ -427,8 +453,8 @@ class VideoReverseTool extends Tool {
         throw new Error('Generated video is empty. Check video format or try different settings.');
       }
       
-      const blob = new Blob([data], { type: file.type });
-      this.displayOutputMedia(blob, 'outputVideo', `reversed_video${getExtension(file.name)}`, 'downloadContainer');
+      const blob = new Blob([data], { type: 'video/mp4' });
+      this.displayOutputMedia(blob, 'outputVideo', 'reversed_video.mp4', 'downloadContainer');
       
       this.updateProgress(100);
       this.log('Video reversal complete!', 'success');

--- a/src/video/trim.js
+++ b/src/video/trim.js
@@ -3,7 +3,14 @@
  */
 import { Tool } from '../common/base.js';
 import { formatFileSize, formatTime } from '../common/utils.js';
-import { loadFFmpeg, writeInputFile, readOutputFile, executeFFmpeg, getExtension } from './ffmpeg-utils.js';
+import {
+  loadFFmpeg,
+  writeInputFile,
+  readOutputFile,
+  executeFFmpeg,
+  getExtension,
+  getX264EncodeArgs
+} from './ffmpeg-utils.js';
 
 // Video trim tool template
 export const template = `
@@ -151,12 +158,9 @@ class VideoTrimTool extends Tool {
     this.initFileUpload({
       acceptTypes: 'video/*',
       onFileSelected: (file) => {
-        this.displayPreview(file, 'inputVideo');
-        this.log(`Loaded video: ${file.name} (${formatFileSize(file.size)})`, 'info');
-        
         // Get video duration when metadata is loaded
         if (this.elements.inputVideo) {
-          this.elements.inputVideo.onloadedmetadata = () => {
+          const applyMetadata = () => {
             this.videoDuration = this.elements.inputVideo.duration;
             
             // Enable inputs
@@ -173,6 +177,26 @@ class VideoTrimTool extends Tool {
             // Initialize the slider
             this.initSlider();
           };
+
+          this.elements.inputVideo.onloadedmetadata = applyMetadata;
+          if (this.elements.inputVideo.readyState >= 1 && Number.isFinite(this.elements.inputVideo.duration)) {
+            applyMetadata();
+          }
+        }
+
+        this.displayPreview(file, 'inputVideo');
+        this.log(`Loaded video: ${file.name} (${formatFileSize(file.size)})`, 'info');
+
+        // Avoid UI deadlock if metadata loading is delayed.
+        this.elements.startTime.disabled = false;
+        this.elements.endTime.disabled = false;
+        this.elements.processBtn.disabled = false;
+        if (!this.videoDuration || !Number.isFinite(this.videoDuration)) {
+          this.videoDuration = 1;
+          this.startTime = 0;
+          this.endTime = 1;
+          this.elements.startTime.value = '0:00';
+          this.elements.endTime.value = '0:01';
         }
       }
     });
@@ -382,20 +406,38 @@ class VideoTrimTool extends Tool {
       this.updateProgress(20);
 
       const inputFileName = 'input' + getExtension(file.name);
-      const outputFileName = 'output' + getExtension(file.name);
+      const sourceExt = getExtension(file.name);
+      let outputFileName = 'output' + sourceExt;
+      let outputMime = file.type || 'video/mp4';
+      let outputDownloadName = `trimmed_video${sourceExt}`;
 
       this.log('Writing input file...', 'info');
       await writeInputFile(this.ffmpeg, inputFileName, file);
       this.updateProgress(30);
 
       this.log('Processing...', 'info');
-      await executeFFmpeg(this.ffmpeg, [
-        '-ss', this.startTime.toString(),
-        '-i', inputFileName,
-        '-t', duration.toString(),
-        '-c', 'copy',
-        '-y', outputFileName
-      ]);
+      try {
+        await executeFFmpeg(this.ffmpeg, [
+          '-ss', this.startTime.toString(),
+          '-i', inputFileName,
+          '-t', duration.toString(),
+          '-c', 'copy',
+          '-y', outputFileName
+        ]);
+      } catch (copyError) {
+        this.log('Fast trim failed, retrying with MP4 re-encode for compatibility...', 'info');
+        outputFileName = 'output.mp4';
+        outputMime = 'video/mp4';
+        outputDownloadName = 'trimmed_video.mp4';
+
+        await executeFFmpeg(this.ffmpeg, [
+          '-ss', this.startTime.toString(),
+          '-i', inputFileName,
+          '-t', duration.toString(),
+          ...getX264EncodeArgs({ quality: 'medium', bitrateKbps: 1600, audio: true, faststart: true }),
+          '-y', outputFileName
+        ]);
+      }
       this.updateProgress(80);
 
       this.log('Reading output file...', 'info');
@@ -405,8 +447,8 @@ class VideoTrimTool extends Tool {
         throw new Error('Generated video is empty. Check video format or try different settings.');
       }
       
-      const blob = new Blob([data], { type: file.type });
-      this.displayOutputMedia(blob, 'outputVideo', `trimmed_video${getExtension(file.name)}`, 'downloadContainer');
+      const blob = new Blob([data], { type: outputMime });
+      this.displayOutputMedia(blob, 'outputVideo', outputDownloadName, 'downloadContainer');
       
       this.updateProgress(100);
       this.log('Trimming complete!', 'success');

--- a/tests/all.spec.js
+++ b/tests/all.spec.js
@@ -56,20 +56,29 @@ test.describe('SafeWebTool Tests', () => {
   
   // Test for specific import errors in all tools
   test('verify all tool modules import correctly', async ({ page }) => {
+    test.setTimeout(180000);
     // This test will verify that each tool module can be imported correctly
-    page.setDefaultTimeout(60000); // Increase timeout to 60 seconds for ML tools
+    page.setDefaultTimeout(60000); // Keep per-action timeout generous for ML tools
     
     for (const [toolPath, toolInfo] of Object.entries(tools)) {
       console.log(`Testing imports for tool: ${toolPath}`);
       
       try {
-        // Navigate with a longer timeout
         await page.goto(`/${toolPath}`, { timeout: 10000 });
-        
-        // Wait for tool to load (longer timeout to accommodate ML and FFmpeg tools)
+
         const category = toolPath.split('/')[0];
-        const waitTime = category === 'ml' ? 15000 : 2000; // Longer wait for ML tools
-        await page.waitForTimeout(waitTime);
+        await expect(page.locator('.tool-page')).toBeVisible();
+        await expect(page.locator('.tool-content-area')).toBeVisible();
+
+        // Prefer readiness signals over fixed sleeps so the test scales as tools are added.
+        const readySelectors = ['#logHeader', '.file-select-btn', 'textarea', 'canvas', '.controls'];
+        const readyLocator = page.locator(readySelectors.join(', ')).first();
+        await readyLocator.waitFor({
+          state: 'attached',
+          timeout: category === 'ml' ? 10000 : 4000
+        }).catch(() => {
+          // Some tools may render progressively; we still continue to import-error checks below.
+        });
         
         // Check that no import error message is shown
         const errorLocator = page.locator('text=Failed to load tool module');

--- a/tests/reencode-downloaded-mp4.spec.js
+++ b/tests/reencode-downloaded-mp4.spec.js
@@ -1,0 +1,40 @@
+// @ts-check
+import { test, expect } from '@playwright/test';
+
+async function clickProcessButton(page) {
+  const button = page.locator('#processBtn');
+  await expect(button).toBeVisible();
+  await button.scrollIntoViewIfNeeded().catch(() => {});
+
+  try {
+    await button.click({ timeout: 5000 });
+  } catch {
+    await button.click({ force: true });
+  }
+}
+
+test('re-encodes downloaded sample MP4 to MP4 (default path)', async ({ page }) => {
+  test.setTimeout(180000);
+
+  await page.goto('/video/reencode');
+  await expect(page.locator('.tool-page')).toBeVisible();
+
+  await page.setInputFiles('#fileInput', '/tmp/sample-test.mp4');
+  await page.fill('#bitrate', '900');
+  await page.selectOption('#format', 'mp4');
+  await clickProcessButton(page);
+
+  const outputVideo = page.locator('#output-video');
+  const downloadLink = page.locator('#downloadContainer a[download]');
+  const logContent = page.locator('#logContent');
+
+  await expect.poll(async () => {
+    const logs = await logContent.inputValue().catch(() => '');
+    if (logs.includes('FFmpeg command failed') || logs.includes('Error: FFmpeg exited') || logs.includes('Error: undefined')) {
+      return `failed:${logs.slice(-400)}`;
+    }
+    const visible = await outputVideo.isVisible().catch(() => false);
+    const hasDownload = await downloadLink.count().then(c => c > 0);
+    return visible && hasDownload ? 'success' : 'pending';
+  }, { timeout: 120000, intervals: [500, 1000, 2000] }).toBe('success');
+});

--- a/tests/reencode-downloaded.spec.js
+++ b/tests/reencode-downloaded.spec.js
@@ -1,0 +1,46 @@
+// @ts-check
+import { test, expect } from '@playwright/test';
+
+async function clickProcessButton(page) {
+  const button = page.locator('#processBtn');
+  await expect(button).toBeVisible();
+  await button.scrollIntoViewIfNeeded().catch(() => {});
+
+  try {
+    await button.click({ timeout: 5000 });
+  } catch {
+    await button.click({ force: true });
+  }
+}
+
+test.describe('Video Re-encode Downloaded File', () => {
+  test('re-encodes a downloaded sample MP4 to WebM', async ({ page }) => {
+    test.setTimeout(180000);
+
+    await page.goto('/video/reencode');
+    await expect(page.locator('.tool-page')).toBeVisible();
+
+    await page.setInputFiles('#fileInput', '/tmp/sample-test.mp4');
+    await page.selectOption('#format', 'webm');
+    await page.fill('#bitrate', '900');
+    await clickProcessButton(page);
+
+    const outputVideo = page.locator('#output-video');
+    const downloadLink = page.locator('#downloadContainer a[download]');
+    const logContent = page.locator('#logContent');
+
+    await expect.poll(async () => {
+      const logs = await logContent.inputValue().catch(() => '');
+      if (logs.includes('FFmpeg command failed') || logs.includes('Error: FFmpeg exited')) {
+        return `failed:${logs.slice(-300)}`;
+      }
+
+      const visible = await outputVideo.isVisible().catch(() => false);
+      const hasDownload = await downloadLink.count().then(c => c > 0);
+      return visible && hasDownload ? 'success' : 'pending';
+    }, { timeout: 120000, intervals: [500, 1000, 2000] }).toBe('success');
+
+    await expect(outputVideo).toBeVisible();
+    await expect(downloadLink).toBeVisible();
+  });
+});

--- a/tests/reencode-real.spec.js
+++ b/tests/reencode-real.spec.js
@@ -1,0 +1,124 @@
+// @ts-check
+import { test, expect } from '@playwright/test';
+
+async function clickProcessButton(page) {
+  const button = page.locator('#processBtn');
+  await expect(button).toBeVisible();
+  await button.scrollIntoViewIfNeeded().catch(() => {});
+
+  try {
+    await button.click({ timeout: 5000 });
+  } catch {
+    await button.click({ force: true });
+  }
+}
+
+async function generateRecordedWebM(page) {
+  const bytes = await page.evaluate(async () => {
+    const mimeTypeCandidates = [
+      'video/webm;codecs=vp8,opus',
+      'video/webm;codecs=vp8',
+      'video/webm'
+    ];
+    const mimeType = mimeTypeCandidates.find(type => window.MediaRecorder?.isTypeSupported?.(type)) || '';
+    if (!window.MediaRecorder) {
+      throw new Error('MediaRecorder is not available in this browser');
+    }
+
+    const canvas = document.createElement('canvas');
+    canvas.width = 320;
+    canvas.height = 180;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) {
+      throw new Error('Canvas 2D context unavailable');
+    }
+
+    const stream = canvas.captureStream(12);
+    const recorder = new MediaRecorder(stream, mimeType ? { mimeType } : undefined);
+    const chunks = [];
+
+    const done = new Promise((resolve, reject) => {
+      recorder.ondataavailable = (event) => {
+        if (event.data && event.data.size > 0) chunks.push(event.data);
+      };
+      recorder.onerror = (event) => reject(new Error(event.error?.message || 'MediaRecorder error'));
+      recorder.onstop = async () => {
+        const blob = new Blob(chunks, { type: recorder.mimeType || 'video/webm' });
+        const arr = new Uint8Array(await blob.arrayBuffer());
+        resolve(Array.from(arr));
+      };
+    });
+
+    recorder.start(100);
+
+    const start = performance.now();
+    await new Promise(resolve => {
+      function draw(now) {
+        const t = (now - start) / 1000;
+        ctx.fillStyle = '#0f172a';
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+        ctx.fillStyle = '#38bdf8';
+        ctx.fillRect(20 + ((t * 80) % 220), 40, 80, 80);
+        ctx.fillStyle = '#e2e8f0';
+        ctx.font = '20px sans-serif';
+        ctx.fillText('SafeWebTool', 80, 150);
+
+        if (t < 1.2) {
+          requestAnimationFrame(draw);
+        } else {
+          resolve(null);
+        }
+      }
+      requestAnimationFrame(draw);
+    });
+
+    recorder.stop();
+    return await done;
+  });
+
+  return Buffer.from(bytes);
+}
+
+test.describe('Video Re-encode Real File', () => {
+  test('re-encodes a generated WebM file to MP4', async ({ page }) => {
+    test.setTimeout(180000);
+
+    await page.goto('/');
+    const inputBuffer = await generateRecordedWebM(page);
+    expect(inputBuffer.byteLength).toBeGreaterThan(0);
+
+    await page.goto('/video/reencode');
+    await expect(page.locator('.tool-page')).toBeVisible();
+
+    await page.setInputFiles('#fileInput', {
+      name: 'recorded.webm',
+      mimeType: 'video/webm',
+      buffer: inputBuffer
+    });
+
+    await page.fill('#bitrate', '1200');
+    await page.selectOption('#format', 'mp4');
+    await clickProcessButton(page);
+
+    // Wait for either success output or explicit FFmpeg failure to surface.
+    const outputVideo = page.locator('#output-video');
+    const errorLog = page.locator('#logContent');
+    const downloadLink = page.locator('#downloadContainer a[download]');
+
+    await expect.poll(async () => {
+      const visible = await outputVideo.isVisible().catch(() => false);
+      const hasDownload = await downloadLink.count().then(c => c > 0);
+      const logs = (await errorLog.inputValue().catch(() => '')) || '';
+      if (logs.includes('FFmpeg command failed') || logs.includes('Error: FFmpeg exited')) {
+        return 'failed';
+      }
+      if (visible && hasDownload) {
+        return 'success';
+      }
+      return 'pending';
+    }, { timeout: 120000, intervals: [500, 1000, 2000] }).toBe('success');
+
+    await expect(outputVideo).toBeVisible();
+    await expect(downloadLink).toBeVisible();
+  });
+});

--- a/tests/video-ops-downloaded.spec.js
+++ b/tests/video-ops-downloaded.spec.js
@@ -1,0 +1,152 @@
+// @ts-check
+import { test, expect } from '@playwright/test';
+
+const SAMPLE_FILE = '/tmp/bunny-small.mp4';
+
+async function clickProcessButton(page, selector = '#processBtn') {
+  const button = page.locator(selector);
+  await expect(button).toBeVisible();
+  await button.scrollIntoViewIfNeeded().catch(() => {});
+
+  try {
+    await button.click({ timeout: 5000 });
+  } catch {
+    await button.click({ force: true });
+  }
+}
+
+async function uploadAndWaitForSuccess(page, {
+  route,
+  inputSelector = '#fileInput',
+  processSelector = '#processBtn',
+  outputSelector = '#output-video',
+  downloadSelector = '#downloadContainer a[download]',
+  beforeProcess
+}) {
+  await page.goto(route);
+  await expect(page.locator('.tool-page')).toBeVisible();
+  await expect(page.locator('.file-select-btn').first()).toBeVisible();
+  await expect(page.locator('#logHeader')).toBeVisible();
+  await expect(page.locator('#logContent')).toHaveCount(1);
+  await expect(page.locator('#progress')).toHaveCount(1);
+  await expect(page.locator('.tool-container[data-tool-ready=\"true\"]')).toBeVisible();
+  await page.setInputFiles(inputSelector, SAMPLE_FILE);
+  await expect.poll(async () => {
+    const inputSrc = await page.locator('#input-video').getAttribute('src').catch(() => '');
+    const logs = await page.locator('#logContent').inputValue().catch(() => '');
+    return (inputSrc && inputSrc.startsWith('blob:')) || logs.includes('Loaded video:');
+  }, { timeout: 5000, intervals: [100, 250, 500] }).toBeTruthy();
+
+  if (beforeProcess) {
+    await beforeProcess(page);
+  }
+
+  const initialLogs = await page.locator('#logContent').inputValue().catch(() => '');
+  await clickProcessButton(page, processSelector);
+
+  await expect.poll(async () => {
+    const logs = await page.locator('#logContent').inputValue().catch(() => '');
+    return logs.length > initialLogs.length || /Writing input file|Processing|Executing FFmpeg/i.test(logs);
+  }, { timeout: 10000, intervals: [250, 500, 1000] }).toBeTruthy();
+
+  await expect.poll(async () => {
+    const progressStyle = await page.locator('#progress').getAttribute('style').catch(() => '');
+    const progressText = await page.locator('#progress').textContent().catch(() => '');
+    return (progressStyle && !progressStyle.includes('display: none')) || /[1-9]\d?%|100%/.test(progressText || '');
+  }, { timeout: 15000, intervals: [250, 500, 1000] }).toBeTruthy();
+
+  const logContent = page.locator('#logContent');
+  await expect.poll(async () => {
+    const logs = await logContent.inputValue().catch(() => '');
+    if (/FFmpeg command failed|Error: FFmpeg exited|Error: FFmpeg aborted/i.test(logs)) {
+      return `failed:${logs.slice(-500)}`;
+    }
+
+    const visible = await page.locator(outputSelector).isVisible().catch(() => false);
+    const hasDownload = await page.locator(downloadSelector).count().then(c => c > 0);
+    return visible && hasDownload ? 'success' : 'pending';
+  }, { timeout: 120000, intervals: [500, 1000, 2000] }).toBe('success');
+
+  await expect(page.locator(outputSelector)).toBeVisible();
+  await expect(page.locator(downloadSelector)).toBeVisible();
+}
+
+test.describe('Video Ops E2E (Big Buck Bunny small sample)', () => {
+  test.describe.configure({ mode: 'serial' });
+  test.beforeAll(async () => {
+    // Ensure the Bunny sample exists for these local e2e checks.
+    // Playwright will surface a clear error if missing when setInputFiles runs.
+  });
+
+  test('reencode default (MP4)', async ({ page }) => {
+    test.setTimeout(180000);
+    await uploadAndWaitForSuccess(page, {
+      route: '/video/reencode',
+      beforeProcess: async (p) => {
+        await p.selectOption('#format', 'mp4');
+        await p.fill('#bitrate', '900');
+      }
+    });
+  });
+
+  test('convert to MP4 tool (default settings)', async ({ page }) => {
+    test.setTimeout(180000);
+    await uploadAndWaitForSuccess(page, {
+      route: '/video/mp4',
+      beforeProcess: async (p) => {
+        await p.fill('#bitrate', '900');
+      }
+    });
+  });
+
+  test('resize video', async ({ page }) => {
+    test.setTimeout(180000);
+    await uploadAndWaitForSuccess(page, {
+      route: '/video/resize',
+      beforeProcess: async (p) => {
+        await p.waitForFunction(() => {
+          const w = document.getElementById('width');
+          return w && !w.disabled;
+        });
+        await p.fill('#width', '320');
+      }
+    });
+  });
+
+  test('trim video short clip', async ({ page }) => {
+    test.setTimeout(180000);
+    await uploadAndWaitForSuccess(page, {
+      route: '/video/trim',
+      beforeProcess: async (p) => {
+        await p.waitForFunction(() => {
+          const start = document.getElementById('startTime');
+          const end = document.getElementById('endTime');
+          return start && end && !start.disabled && !end.disabled;
+        });
+        await p.fill('#startTime', '0:00');
+        await p.dispatchEvent('#startTime', 'change');
+        await p.fill('#endTime', '0:01');
+        await p.dispatchEvent('#endTime', 'change');
+      }
+    });
+  });
+
+  test('reverse video short clip (audio removed default)', async ({ page }) => {
+    test.setTimeout(180000);
+    await uploadAndWaitForSuccess(page, {
+      route: '/video/reverse',
+      beforeProcess: async (p) => {
+        await p.waitForFunction(() => {
+          const start = document.getElementById('startTime');
+          const end = document.getElementById('endTime');
+          const removeAudio = document.getElementById('removeAudio');
+          return start && end && removeAudio && !start.disabled && !end.disabled && !removeAudio.disabled;
+        });
+        await p.fill('#startTime', '0:00');
+        await p.dispatchEvent('#startTime', 'change');
+        await p.fill('#endTime', '0:01');
+        await p.dispatchEvent('#endTime', 'change');
+      }
+    });
+  });
+});

--- a/tests/video-ui-consistency.spec.js
+++ b/tests/video-ui-consistency.spec.js
@@ -1,0 +1,21 @@
+// @ts-check
+import { test, expect } from '@playwright/test';
+import { tools } from '../src/common/metadata.js';
+
+const videoToolPaths = Object.keys(tools).filter(path => path.startsWith('video/'));
+
+test.describe('Video Tool UI Consistency', () => {
+  test('all video tools show logs and a progress UI', async ({ page }) => {
+    test.setTimeout(120000);
+
+    for (const toolPath of videoToolPaths) {
+      await page.goto(`/${toolPath}`);
+      await expect(page.locator('.tool-page')).toBeVisible();
+      await expect(page.locator('#logHeader')).toBeVisible();
+      await expect(page.locator('#logContent')).toHaveCount(1);
+
+      const progressCount = await page.locator('#progress, #videoProgress').count();
+      expect(progressCount).toBeGreaterThan(0);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- refactor routing/tool loading with a central tool registry and shared page renderers
- harden browser video tools (ffmpeg error handling, faster defaults, upload wiring, output visibility, fallback paths)
- add real-file video e2e coverage (including Big Buck Bunny sample) and UI consistency checks
- bump app version to 1.0.8

## Validation
- npm run test:chrome -- --reporter=line (108 passed)
