### PR TITLE
Make tools easier to extend: scaffold kinds, auto-metadata, test stubs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,145 @@
+# CLAUDE.md — SafeWebTool
+
+Claude-specific context for working in this repo. Start here, then read `AGENTS.md` for the full agent guide and `documentation/tool-architecture-playbook.md` for the scaling workflow.
+
+## Project Identity
+
+SafeWebTool is a privacy-first, open-source collection of browser-local tools at [safewebtool.com](https://safewebtool.com). **All processing happens in the user's browser. No file uploads, no server, no login, no ads.**
+
+Stack: Vite + Tailwind CSS + vanilla JS ES modules. Deployed on Netlify. Tests use Playwright.
+
+## Claude's Role in This Repo
+
+You are a contributor, not a reviewer. When asked to add a tool, fix a bug, or refactor shared code, **do the work** — scaffold, implement, run contract checks, and verify tests pass. Don't just describe what to do.
+
+## Cardinal Rules (Never Violate)
+
+1. **No server calls from tool logic.** Tools may use CDN-hosted WASM/ML models, but never POST user files to a remote server.
+2. **Privacy-first.** Never add analytics, tracking, or third-party data collection to tool pages.
+3. **No router edits for normal tool additions.** The dynamic import glob in `tool-registry.js` discovers tools automatically. Adding metadata + a module file is enough.
+4. **Minimal code.** Prefer reusing `src/common/*` over copy-pasting. Avoid bloated libraries or excessive comments.
+5. **Mobile-first.** Tools must work and look correct on small screens.
+
+## Architecture at a Glance
+
+```
+src/
+  common/
+    metadata.js        ← source of truth: categories + tool metadata (SEO, cards, discovery)
+    tool-registry.js   ← route parsing + dynamic module loading (do not add tool-specific cases here)
+    page-renderers.js  ← renders category pages + tool shell
+    base.js            ← Tool base class (logs, progress, process button, file upload wiring)
+    fileUpload.js      ← shared drag/drop + file input (delegated events — safe after re-renders)
+    utils.js           ← addLog, updateProgress, formatFileSize, etc.
+    footer-manager.js  ← custom per-tool footers
+  <category>/
+    <toolId>.js        ← tool module: export template + initTool()
+  video/
+    ffmpeg-utils.js    ← FFmpeg WASM wrapper, presets, error handling
+```
+
+## Adding a Tool (Fast Path)
+
+```bash
+npm run scaffold:tool -- image/my-tool --name="My Tool" --icon="🧰" [--kind=file|text|generator]
+```
+
+The scaffold creates the module, **auto-inserts the metadata entry** into `src/common/metadata.js`, and writes a smoke test at `tests/<category>-<toolId>.spec.js`. Pick `--kind`:
+
+- `file` (default) — drop zone + process button (image/video/ml tools)
+- `text` — input → output textareas with copy/download (text utilities)
+- `generator` — options → generated output (password/uuid/hash)
+
+Then:
+1. Implement the scaffolded `processFile()` / `processText()` / `generate()` with real browser-local logic.
+2. Refine the auto-inserted metadata (keywords, `howToUse`, `useCase`) in `src/common/metadata.js`.
+3. Run `npm run test:tool -- image/my-tool` to verify.
+
+Flags: `--no-metadata` (print the entry instead of inserting), `--no-test` (skip the test stub).
+
+### Required metadata fields
+
+`id`, `category`, `name`, `description`, `icon`, `keywords`, `howToUse`, `useCase`
+
+Key format in `tools` object: `"<category>/<toolId>"` — must match the file path and `tool.id` / `tool.category` values.
+
+### Tool module contract
+
+- Export `template` — HTML string with the tool UI
+- Export `initTool()` — called by the router after the shell renders
+- Extend `Tool` from `src/common/base.js` for consistent behavior (logs, progress, process button, file upload, `data-tool-ready` marker)
+
+### DOM IDs to preserve (tests depend on these)
+
+| ID | Purpose |
+|----|---------|
+| `dropZone` | File drop area |
+| `fileInput` | Hidden file input |
+| `processBtn` | Process trigger button |
+| `progress` / `videoProgress` | Progress bar |
+| `logHeader` / `logContent` | Collapsible log panel |
+| `input-video` / `output-video` | Video preview elements (video tools) |
+| `downloadContainer` | Output download link area |
+
+## Test Commands (Use These, In This Order)
+
+```bash
+# 1. Fast contract check (always run first)
+npm run test:contract
+
+# 2. Smoke test one tool
+npm run test:tool -- <category/toolId>
+
+# 3. With mobile + real file
+npm run test:tool -- <category/toolId> --mobile --real
+
+# 4. Full regression (before PR or cross-cutting changes)
+npm run verify:full
+```
+
+Run `npm run verify:full` when touching: routing, shared base/upload utilities, FFmpeg helpers, or multiple tools at once.
+
+## Video Tools — Extra Care
+
+- FFmpeg WASM is slower than desktop — use fast presets: H.264 `ultrafast`-ish, VP8 (`libvpx`) over VP9.
+- Normalize FFmpeg failures early; don't let empty output silently look like success.
+- All video tool pages need: log panel, progress bar, output preview, download link.
+- Validate against `tests/video-ui-consistency.spec.js` after video tool changes.
+
+## Common Bugs to Avoid
+
+- **Upload button breaks after re-render**: `fileUpload.js` uses delegated events — don't re-initialize in a way that creates duplicate listeners.
+- **FFmpeg failed but UI looks OK**: Always check exit code in `ffmpeg-utils.js`, not just log output.
+- **Empty output file**: Downstream symptom of a decode/encode error — fix root cause, not symptoms.
+- **Mobile test click interception**: Use `scrollIntoViewIfNeeded()` + `click({ force: true })` in Playwright tests.
+
+## Generated Files — Do Not Hand-Edit
+
+These are regenerated from `src/common/metadata.js` and build scripts:
+- `public/llms.txt`
+- `public/tools.json`
+- `public/**/agent.json`
+- `public/og/safewebtool.png`
+
+After metadata changes: `npm run generate:agent-manifest && npm run generate:share-image`
+
+## Scaffold for a New Category
+
+Add the category to `src/common/metadata.js` under `categories` first (with `id`, `name`, `description`, `icon`, `keywords`). The registry discovers it automatically — no router edit needed.
+
+## Before Every PR
+
+- [ ] `npm run test:contract` passes
+- [ ] `npm run test:tool -- <category/toolId>` passes for changed tools
+- [ ] `npm run verify:full` passes for cross-cutting changes
+- [ ] No router edits unless route semantics changed
+- [ ] No server calls added to tool logic
+- [ ] Generated files regenerated if metadata changed
+
+## Key Conventions Claude Should Follow
+
+- Keep tool modules thin — processing logic goes in the module, structural/shared patterns in `src/common/*`.
+- Don't import one tool module from another.
+- Don't add global side effects in shared utilities.
+- Commit messages: specific to user-facing or architectural impact; include what was tested.
+- Prefer `Tool` base class over hand-rolling logs/progress/button wiring.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ You are a contributor, not a reviewer. When asked to add a tool, fix a bug, or r
 ## Cardinal Rules (Never Violate)
 
 1. **No server calls from tool logic.** Tools may use CDN-hosted WASM/ML models, but never POST user files to a remote server.
-2. **Privacy-first.** Never add analytics, tracking, or third-party data collection to tool pages.
+2. **Privacy-first.** Tool processing logic must never send user files or file content to any analytics/tracking/third-party service. The site already loads anonymous, page-view-only Google Analytics (`src/main.js`, gated off localhost) for usage stats — that's intentional and should be preserved, not removed. Don't add new tracking, and don't add any analytics calls inside tool modules.
 3. **No router edits for normal tool additions.** The dynamic import glob in `tool-registry.js` discovers tools automatically. Adding metadata + a module file is enough.
 4. **Minimal code.** Prefer reusing `src/common/*` over copy-pasting. Avoid bloated libraries or excessive comments.
 5. **Mobile-first.** Tools must work and look correct on small screens.

--- a/documentation/improvement-plan.md
+++ b/documentation/improvement-plan.md
@@ -1,0 +1,222 @@
+# SafeWebTool Improvement Plan
+
+Analysis date: 2026-06-13. Based on audit of all source files, tests, and documentation.
+
+---
+
+## Summary
+
+SafeWebTool has a strong architecture (thin tool modules, shared base class, contract validation, automated scaffolding) and a clear privacy-first philosophy. The gaps are primarily: tool breadth, a few privacy inconsistencies, test coverage holes, and several quick DX wins.
+
+---
+
+## Priority 0 — Make Adding a Tool Frictionless (Extensibility)
+
+The architecture already supports zero-router-edit tool additions. The remaining friction is all in the **scaffold workflow** — these are the highest-leverage changes because every future tool benefits.
+
+### 0.1 Scaffold auto-inserts metadata (was: hand-paste)
+
+`npm run scaffold:tool` used to print a metadata block to the terminal for you to paste into `src/common/metadata.js` by hand — the single most error-prone step (wrong key, missing comma, mismatched `id`/`category`). The scaffold now **writes the metadata entry directly** into the `tools` object in `metadata.js`. Pass `--no-metadata` to opt out.
+
+### 0.2 Scaffold supports template kinds
+
+A single file-upload template forced every text/time/math/privacy tool to rewrite the whole module. The scaffold now takes `--kind`:
+
+| `--kind` | Shape | Good for |
+|----------|-------|----------|
+| `file` (default) | Drop zone + process button + logs | image/video/ml tools |
+| `text` | Input textarea → action → output textarea + copy/download | base64, case-converter, word-count, JSON/YAML |
+| `generator` | Options + generate button → output + copy | password, UUID, hash, lorem-ipsum |
+
+Each kind wires the right `Tool` config (`needsFileUpload`, `hasOutput`) and exposes predictable DOM IDs.
+
+### 0.3 Scaffold generates a matching test stub
+
+The scaffold now writes `tests/<category>-<toolId>.spec.js` with a smoke check (page loads, `data-tool-ready` marker, key elements present) tuned to the chosen kind. Pass `--no-test` to opt out. This closes the §1.3 / §3.2 gap going forward.
+
+### 0.4 Build chunking covers every category
+
+`vite.config.js` `entryFileNames` only preserved `video|image|text` paths and used `[a-z-]+` (which silently missed digit-containing tool IDs like `ml/image2text`). It now matches any category directory and digit-containing IDs, so `ml/` and `time/` tools get stable, path-preserving chunk names too.
+
+**Net effect:** adding a tool is now `scaffold:tool` → fill in `processFile`/`processText`/`generate` → `test:tool`. No manual metadata edit, no router edit, no test boilerplate.
+
+---
+
+## Priority 1 — Fix Before Adding More Tools
+
+These are correctness and consistency issues that compound with scale.
+
+### 1.1 Reconcile the privacy wording with Google Analytics (keep GA)
+
+**Decision:** Google Analytics stays. `src/main.js` keeps loading GA (`G-SK7DDP7ND6`), already gated to skip localhost and deferred to idle (`scheduleAnalytics`). The brand promise is specifically about **files**, not page-view analytics — so the fix is wording, not removal.
+
+The homepage and metadata say "No ads, no tracking" / "no tracking" in a few places. GA is page-level analytics, but the privacy claim that matters is "your files never leave your browser." Make the copy precise so it stays true:
+
+- Keep the strong, accurate claims: **No file uploads. No login. No ads. No paywalls.** (these are all true and are the real differentiator)
+- Drop the unqualified "no tracking" phrasing where it appears, or qualify it as "no third-party file tracking / your files are never uploaded."
+- Files to check: `src/common/metadata.js` (`siteInfo.philosophy`, `keywords`), `src/common/page-renderers.js` hero pills, `index.html` static copy.
+
+This keeps GA (anonymous page analytics for understanding which tools are used) while making sure no on-page claim overstates the privacy posture.
+
+### 1.2 Navigation in `index.html` is duplicated
+
+The top-nav flyout menus in `index.html` are hardcoded HTML, while `src/main.js` also dynamically renders the nav from metadata. The two can drift. The hardcoded flyout has links that `main.js` doesn't replicate.
+
+**Fix:** Drive the flyout from metadata too, or clearly designate which is the source of truth and remove the other.
+
+### 1.3 Missing dedicated tests for several tools
+
+No focused test for: `image/crop`, `ml/face_detect`, `ml/image2text`, `ml/transcribe`, `text/remove-extra-spaces`, `text/editor`.
+
+**Fix:** Add smoke specs following the existing `image-tools-e2e.spec.js` and `time-tools.spec.js` pattern. These don't need real-file coverage — just that the page loads, the tool-ready marker appears, and the UI elements are present.
+
+---
+
+## Priority 2 — High-Value New Tools (Low Implementation Risk)
+
+These use no new dependencies, follow existing patterns (text/time tools are pure JS, image tools use Canvas API), and can be shipped with `npm run scaffold:tool`.
+
+### Text Tools
+
+| Tool | Path | Why |
+|------|------|-----|
+| Markdown preview | `text/markdown` | Very high search volume; pure JS (marked.js or micro-parser) |
+| CSV viewer | `text/csv` | Tabular data preview in-browser; no library needed |
+| Base64 encode/decode | `text/base64` | Developer staple; 5 lines of logic |
+| URL encode/decode | `text/url-encode` | Same; `encodeURIComponent` / `decodeURIComponent` |
+| Word counter | `text/word-count` | Simple, broad audience |
+| HTML formatter / minifier | `text/html-formatter` | Pairs with existing JSON/YAML tools |
+| Regex tester | `text/regex` | Developer-focused; vanilla JS |
+| Lorem ipsum generator | `text/lorem-ipsum` | Quick win |
+| Case converter | `text/case-converter` | camelCase ↔ snake_case ↔ UPPER ↔ Title |
+| Diff viewer | `text/diff` | Side-by-side text diff; can use browser's native `Intl` or a tiny lib |
+
+### Image Tools
+
+| Tool | Path | Why |
+|------|------|-----|
+| Image format converter | `image/convert` | JPEG ↔ PNG ↔ WebP ↔ AVIF via Canvas; very high demand |
+| Color picker from image | `image/color-picker` | Eyedropper on canvas; popular utility |
+| Image metadata viewer | `image/metadata` | EXIF data via small JS lib (exifr); pairs with video/info |
+| Background remover | `image/bg-remove` | Uses `@huggingface/transformers` (already a dep); ML-powered |
+| Favicon generator | `image/favicon` | Canvas resize to ICO/PNG sizes; popular use case |
+| QR code generator | `image/qr-code` | qrcode.js (~10KB); entirely browser-local |
+| Image to PDF | `image/to-pdf` | jsPDF in-browser; no upload needed |
+
+### Time Tools
+
+| Tool | Path | Why |
+|------|------|-----|
+| Pomodoro timer | `time/pomodoro` | Extends existing timer; high search volume |
+| Epoch / Unix timestamp converter | `time/epoch` | Developer staple |
+| Age calculator | `time/age` | Simple date math; broad audience |
+| Countdown to date | `time/countdown` | Simple extension of existing timer logic |
+
+### New Category: Math / Numbers
+
+| Tool | Path | Why |
+|------|------|-----|
+| Percentage calculator | `math/percentage` | Extremely high search volume |
+| Unit converter | `math/unit-convert` | Comprehensive (length, weight, temp, speed) |
+| Random number generator | `math/random` | Simple; useful |
+| Number base converter | `math/base-convert` | Binary ↔ Decimal ↔ Hex ↔ Octal |
+| Loan / mortgage calculator | `math/loan` | Genuinely useful; complex enough to justify a tool |
+
+### New Category: Privacy / Security (aligns perfectly with brand)
+
+| Tool | Path | Why |
+|------|------|-----|
+| Password generator | `privacy/password` | Browser-local `crypto.getRandomValues`; no library needed |
+| Password strength checker | `privacy/password-check` | Pairs with generator |
+| Hash generator (MD5/SHA) | `privacy/hash` | Browser `crypto.subtle`; developer use case |
+| UUID generator | `privacy/uuid` | `crypto.randomUUID()`; trivial to implement |
+
+---
+
+## Priority 3 — Architecture & DX Improvements
+
+### 3.1 Search is not prominently discoverable
+
+The global search exists (`#globalToolSearch`) but is not visible on mobile without scrolling. With 30+ tools incoming, discoverability becomes critical.
+
+**Fix:** Make the search bar sticky or add it to the mobile header. Consider auto-focusing it on `/` keypress.
+
+### 3.2 Tool scaffold doesn't generate a test stub — ✅ done (see §0.3)
+
+Implemented in Priority 0: `scripts/scaffold-tool.mjs` now writes `tests/<category>-<toolId>.spec.js` with a kind-aware smoke check.
+
+### 3.3 No "recently added" or "featured" sorting on homepage
+
+All categories expand the same way with no signals about what's new or popular.
+
+**Fix:** Add an optional `featured: true` and/or `addedAt: '2026-01-01'` field to metadata, then surface a "New" badge and a "Recently added" section on the homepage.
+
+### 3.4 `vite.config.js` manualChunks doesn't cover `ml/` and `time/` — ✅ done (see §0.4)
+
+Implemented in Priority 0: the `entryFileNames` regex now matches any category directory and digit-containing tool IDs.
+
+### 3.5 Category pages don't have breadcrumbs or back-links
+
+Navigating to `/image` gives no visual path back to home. Breadcrumbs improve both UX and SEO.
+
+**Fix:** Add a simple `Home > Image Tools` breadcrumb in `page-renderers.js` for category and tool pages.
+
+---
+
+## Priority 4 — SEO and Discoverability
+
+### 4.1 Per-tool OG images
+
+Currently all tools share the same `/og/safewebtool.png`. Tools with custom OG images rank better and have better social share previews.
+
+**Fix:** Extend `scripts/generate-share-image.mjs` to generate a per-tool OG image (tool name + icon + site branding) using `@napi-rs/canvas` or similar in the build step.
+
+### 4.2 `llms.txt` is the only agent entry point from root
+
+The site follows the `llms.txt` spec but doesn't link to it from `<head>`. Some AI crawlers look for a `<link rel="llms" href="/llms.txt">` convention.
+
+**Fix:** Add the link tag to `index.html` head (1-line fix).
+
+### 4.3 Structured data is per-tool but not present on category pages
+
+Category pages currently have no JSON-LD, which is a missed SEO opportunity for landing pages like `/image`.
+
+**Fix:** Add `ItemList` structured data on category pages listing all tool URLs within.
+
+---
+
+## Priority 5 — Performance
+
+### 5.1 ML models are downloaded at runtime on first use
+
+`@huggingface/transformers` fetches model weights when the tool first runs, with no pre-cache or progress indicator beyond the generic log.
+
+**Fix:** Add a clear model-download progress bar (size, %) separate from the processing progress. Consider caching models to `CacheStorage` on first download to skip the fetch on return visits.
+
+### 5.2 FFmpeg WASM is re-fetched on each tool load
+
+FFmpeg WASM (~10MB) has no persistent cross-session cache.
+
+**Fix:** Use `CacheStorage` to cache WASM bytes after first download. Detect cache presence and show a faster "resuming" state instead of "loading FFmpeg."
+
+### 5.3 No `<link rel="preconnect">` for CDN resources
+
+HuggingFace CDN and jsDelivr are used at runtime but not preconnected in `<head>`.
+
+**Fix:** Add `<link rel="preconnect" href="https://cdn.jsdelivr.net">` and `<link rel="preconnect" href="https://huggingface.co">` to `index.html`.
+
+---
+
+## Suggested Delivery Order
+
+If shipping in sprints:
+
+1. **Sprint 1** — Fix GA/privacy (1.1), remove nav duplication (1.2), add missing smoke tests (1.3)
+2. **Sprint 2** — Text tools batch: base64, url-encode, markdown, word-count, case-converter (quickest wins)
+3. **Sprint 3** — Privacy/Security category: password generator, hash, UUID (brand-aligned, high demand)
+4. **Sprint 4** — Image tools: format converter, QR code, favicon generator
+5. **Sprint 5** — Math category, remaining text tools
+6. **Sprint 6** — Performance: WASM/model caching, per-tool OG images, breadcrumbs
+7. **Ongoing** — One new tool per week using `npm run scaffold:tool` workflow
+
+Each sprint is independently shippable. Contract and smoke tests catch regressions before merge.

--- a/netlify.toml
+++ b/netlify.toml
@@ -56,6 +56,18 @@
     Content-Type = "text/javascript"
     Cache-Control = "public, max-age=86400"
 
+[[headers]]
+  for = "/ml/*.js"
+  [headers.values]
+    Content-Type = "text/javascript"
+    Cache-Control = "public, max-age=86400"
+
+[[headers]]
+  for = "/time/*.js"
+  [headers.values]
+    Content-Type = "text/javascript"
+    Cache-Control = "public, max-age=86400"
+
 [[redirects]]
   from = "/*"
   to = "/index.html"

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "autoprefixer": "^10.4.21",
         "postcss": "^8.5.3",
         "tailwindcss": "^3.4.17",
-        "vite": "^5.1.4"
+        "vite": "^6.4.3"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -46,394 +46,419 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
-      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "aix"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
-      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
       "cpu": [
         "arm"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
-      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
-      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
-      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
-      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
-      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
-      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
-      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
       "cpu": [
         "arm"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
-      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
-      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
       "cpu": [
         "ia32"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
-      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
       "cpu": [
         "loong64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
-      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
       "cpu": [
         "mips64el"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
-      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
-      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
-      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
-      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
-      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
       "cpu": [
-        "x64"
+        "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "netbsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
-      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
       "optional": true,
       "os": [
         "openbsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
-      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
       "optional": true,
       "os": [
         "sunos"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
-      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
-      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
       "cpu": [
         "ia32"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
-      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@ffmpeg/core": {
@@ -1836,42 +1861,44 @@
       "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="
     },
     "node_modules/esbuild": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
-      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "MIT",
       "bin": {
         "esbuild": "bin/esbuild"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.21.5",
-        "@esbuild/android-arm": "0.21.5",
-        "@esbuild/android-arm64": "0.21.5",
-        "@esbuild/android-x64": "0.21.5",
-        "@esbuild/darwin-arm64": "0.21.5",
-        "@esbuild/darwin-x64": "0.21.5",
-        "@esbuild/freebsd-arm64": "0.21.5",
-        "@esbuild/freebsd-x64": "0.21.5",
-        "@esbuild/linux-arm": "0.21.5",
-        "@esbuild/linux-arm64": "0.21.5",
-        "@esbuild/linux-ia32": "0.21.5",
-        "@esbuild/linux-loong64": "0.21.5",
-        "@esbuild/linux-mips64el": "0.21.5",
-        "@esbuild/linux-ppc64": "0.21.5",
-        "@esbuild/linux-riscv64": "0.21.5",
-        "@esbuild/linux-s390x": "0.21.5",
-        "@esbuild/linux-x64": "0.21.5",
-        "@esbuild/netbsd-x64": "0.21.5",
-        "@esbuild/openbsd-x64": "0.21.5",
-        "@esbuild/sunos-x64": "0.21.5",
-        "@esbuild/win32-arm64": "0.21.5",
-        "@esbuild/win32-ia32": "0.21.5",
-        "@esbuild/win32-x64": "0.21.5"
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
       }
     },
     "node_modules/escalade": {
@@ -3287,6 +3314,51 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -3368,21 +3440,23 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "5.4.19",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.19.tgz",
-      "integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.21.3",
-        "postcss": "^8.4.43",
-        "rollup": "^4.20.0"
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
       },
       "bin": {
         "vite": "bin/vite.js"
       },
       "engines": {
-        "node": "^18.0.0 || >=20.0.0"
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
       },
       "funding": {
         "url": "https://github.com/vitejs/vite?sponsor=1"
@@ -3391,17 +3465,23 @@
         "fsevents": "~2.3.3"
       },
       "peerDependencies": {
-        "@types/node": "^18.0.0 || >=20.0.0",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
         "less": "*",
         "lightningcss": "^1.21.0",
         "sass": "*",
         "sass-embedded": "*",
         "stylus": "*",
         "sugarss": "*",
-        "terser": "^5.4.0"
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
       },
       "peerDependenciesMeta": {
         "@types/node": {
+          "optional": true
+        },
+        "jiti": {
           "optional": true
         },
         "less": {
@@ -3424,6 +3504,29 @@
         },
         "terser": {
           "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
         }
       }
     },
@@ -3440,6 +3543,18 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
     "autoprefixer": "^10.4.21",
     "postcss": "^8.5.3",
     "tailwindcss": "^3.4.17",
-    "vite": "^5.1.4"
+    "vite": "^6.4.3"
   }
 }

--- a/scripts/scaffold-tool.mjs
+++ b/scripts/scaffold-tool.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { categories } from '../src/common/metadata.js';
@@ -7,15 +7,32 @@ import { categories } from '../src/common/metadata.js';
 const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const args = process.argv.slice(2);
 const toolPath = args.find(arg => !arg.startsWith('--'));
-const nameArg = args.find(arg => arg.startsWith('--name='));
-const iconArg = args.find(arg => arg.startsWith('--icon='));
-const descriptionArg = args.find(arg => arg.startsWith('--description='));
+
+const KINDS = ['file', 'text', 'generator'];
+
+function getFlag(name) {
+  const prefix = `--${name}=`;
+  const arg = args.find(a => a.startsWith(prefix));
+  return arg ? arg.slice(prefix.length) : null;
+}
 
 function usage() {
   console.error([
-    'Usage: npm run scaffold:tool -- <category/toolId> --name="Tool Name" [--icon="🧰"] [--description="Short description"]',
+    'Usage: npm run scaffold:tool -- <category/toolId> --name="Tool Name" [options]',
     '',
-    'This creates src/<category>/<toolId>.js and prints the metadata entry to add to src/common/metadata.js.'
+    'Options:',
+    '  --name="Tool Name"        Display name (defaults to a title-cased id)',
+    '  --icon="🧰"               Emoji icon (defaults to the category icon)',
+    '  --description="..."       Short description for cards/SEO',
+    '  --kind=file|text|generator  UI shape (default: file)',
+    '                              file      → drop zone + process button (image/video/ml)',
+    '                              text      → input → output textareas (text utilities)',
+    '                              generator → options → output (password/uuid/hash)',
+    '  --no-metadata             Do not auto-insert the metadata entry',
+    '  --no-test                 Do not generate a test stub',
+    '',
+    'Creates src/<category>/<toolId>.js, inserts metadata into src/common/metadata.js,',
+    'and writes tests/<category>-<toolId>.spec.js.'
   ].join('\n'));
 }
 
@@ -25,6 +42,13 @@ function titleFromId(toolId) {
     .filter(Boolean)
     .map(part => part.charAt(0).toUpperCase() + part.slice(1))
     .join(' ');
+}
+
+function classNameFromId(toolId) {
+  return `${toolId
+    .split('-')
+    .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+    .join('')}Tool`;
 }
 
 if (!toolPath || !toolPath.includes('/')) {
@@ -43,28 +67,30 @@ if (!categories[categoryId]) {
   process.exit(1);
 }
 
-const name = nameArg ? nameArg.slice('--name='.length) : titleFromId(toolId);
-const icon = iconArg ? iconArg.slice('--icon='.length) : categories[categoryId].icon;
-const description = descriptionArg
-  ? descriptionArg.slice('--description='.length)
-  : `${name} runs locally in your browser. No uploads required.`;
-
-const categoryDir = path.join(rootDir, 'src', categoryId);
-const modulePath = path.join(categoryDir, `${toolId}.js`);
-
-if (existsSync(modulePath)) {
-  console.error(`Refusing to overwrite existing module: ${path.relative(rootDir, modulePath)}`);
+const kind = (getFlag('kind') || 'file').toLowerCase();
+if (!KINDS.includes(kind)) {
+  console.error(`Unknown --kind "${kind}". Use one of: ${KINDS.join(', ')}.`);
   process.exit(1);
 }
 
-mkdirSync(categoryDir, { recursive: true });
+const name = getFlag('name') || titleFromId(toolId);
+const icon = getFlag('icon') || categories[categoryId].icon;
+const description = getFlag('description') || `${name} runs locally in your browser. No uploads required.`;
+const skipMetadata = args.includes('--no-metadata');
+const skipTest = args.includes('--no-test');
 
-const className = `${toolId
-  .split('-')
-  .map(part => part.charAt(0).toUpperCase() + part.slice(1))
-  .join('')}Tool`;
+const className = classNameFromId(toolId);
 
-const moduleSource = `import { Tool } from '../common/base.js';
+const logSection = `    <div class="log-section">
+      <button id="logHeader" class="log-header" type="button">Logs</button>
+      <textarea id="logContent" class="log-content" readonly></textarea>
+    </div>`;
+
+// ---------------------------------------------------------------------------
+// Module templates per kind
+// ---------------------------------------------------------------------------
+function fileModule() {
+  return `import { Tool } from '../common/base.js';
 
 export const template = \`
   <div class="tool-container space-y-6">
@@ -81,10 +107,7 @@ export const template = \`
       <span class="progress-text">0%</span>
     </div>
 
-    <div class="log-section">
-      <button id="logHeader" class="log-header" type="button">Logs</button>
-      <textarea id="logContent" class="log-content" readonly></textarea>
-    </div>
+${logSection}
   </div>
 \`;
 
@@ -127,6 +150,7 @@ class ${className} extends Tool {
 
     try {
       this.log(\`Processing \${file.name}...\`, 'info');
+      // TODO: implement browser-local processing here.
       this.updateProgress(100);
       this.log('Processing complete.', 'success');
     } catch (error) {
@@ -144,23 +168,316 @@ export function initTool() {
   return tool.init();
 }
 `;
+}
 
-writeFileSync(modulePath, moduleSource);
+function textModule() {
+  return `import { Tool } from '../common/base.js';
 
-console.log(`Created ${path.relative(rootDir, modulePath)}`);
-console.log('\nAdd this metadata entry to src/common/metadata.js under tools:\n');
-console.log(`  '${toolPath}': {
+export const template = \`
+  <div class="tool-container space-y-4">
+    <div>
+      <label for="inputText" class="block font-bold text-lg mb-1 text-slate-700 dark:text-slate-200">Input</label>
+      <textarea id="inputText" rows="8" class="w-full min-h-[160px] p-3 border border-slate-300 dark:border-gray-600 rounded-md font-sans text-base resize-y bg-white dark:bg-gray-800 text-slate-900 dark:text-slate-100 focus:outline-none focus:ring-1 focus:ring-blue-500 transition-colors" placeholder="Paste your text here..."></textarea>
+    </div>
+
+    <div class="text-center">
+      <button type="button" id="processBtn" class="px-6 py-2 bg-blue-600 dark:bg-blue-500 text-white rounded-md hover:bg-blue-700 dark:hover:bg-blue-600 transition-colors text-sm font-medium">${name}</button>
+    </div>
+
+    <div>
+      <label for="outputText" class="block font-bold text-lg mb-1 text-slate-700 dark:text-slate-200">Output</label>
+      <textarea id="outputText" rows="8" class="w-full min-h-[160px] p-3 border border-slate-300 dark:border-gray-600 rounded-md font-sans text-base resize-y bg-slate-50 dark:bg-gray-800 text-slate-900 dark:text-slate-100 focus:outline-none focus:ring-1 focus:ring-blue-500 transition-colors" readonly placeholder="Result will appear here..."></textarea>
+    </div>
+
+    <div class="text-center space-x-2">
+      <button id="copyBtn" class="px-4 py-2 bg-slate-600 dark:bg-slate-500 hover:bg-slate-700 dark:hover:bg-slate-600 text-white rounded-md text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed transition-colors" disabled>Copy</button>
+      <button id="downloadBtn" class="px-4 py-2 bg-green-600 dark:bg-green-500 hover:bg-green-700 dark:hover:bg-green-600 text-white rounded-md text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed transition-colors" disabled>Download</button>
+    </div>
+
+${logSection}
+  </div>
+\`;
+
+class ${className} extends Tool {
+  constructor() {
+    super({
+      id: '${toolId}',
+      name: '${name}',
+      category: '${categoryId}',
+      needsFileUpload: false,
+      needsProcessButton: false,
+      hasOutput: true,
+      template
+    });
+  }
+
+  getElementsMap() {
+    return {
+      inputText: 'inputText',
+      outputText: 'outputText',
+      processBtn: 'processBtn',
+      copyBtn: 'copyBtn',
+      downloadBtn: 'downloadBtn',
+      logHeader: 'logHeader',
+      logContent: 'logContent'
+    };
+  }
+
+  async setup() {
+    this.elements.processBtn?.addEventListener('click', () => this.processText());
+    this.elements.copyBtn?.addEventListener('click', () => this.copyOutput());
+    this.elements.downloadBtn?.addEventListener('click', () => this.downloadOutput());
+    this.log('${name} ready', 'info');
+  }
+
+  processText() {
+    const input = this.elements.inputText.value;
+    // TODO: implement the transform.
+    const output = input;
+    this.elements.outputText.value = output;
+    const hasOutput = output.length > 0;
+    this.elements.copyBtn.disabled = !hasOutput;
+    this.elements.downloadBtn.disabled = !hasOutput;
+    this.log('Done.', 'success');
+  }
+
+  async copyOutput() {
+    const text = this.elements.outputText.value;
+    if (!text) return;
+    try {
+      await navigator.clipboard.writeText(text);
+      this.elements.copyBtn.textContent = 'Copied!';
+      setTimeout(() => { this.elements.copyBtn.textContent = 'Copy'; }, 1500);
+    } catch (error) {
+      this.log(\`Failed to copy: \${error.message}\`, 'error');
+    }
+  }
+
+  downloadOutput() {
+    const text = this.elements.outputText.value;
+    if (!text.trim()) return;
+    const blob = new Blob([text], { type: 'text/plain;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = '${toolId}-output.txt';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+    this.log('Downloaded.', 'success');
+  }
+}
+
+export function initTool() {
+  const tool = new ${className}();
+  return tool.init();
+}
+`;
+}
+
+function generatorModule() {
+  return `import { Tool } from '../common/base.js';
+
+export const template = \`
+  <div class="tool-container space-y-4">
+    <div class="space-y-3" id="options">
+      <!-- TODO: add option inputs (sliders, checkboxes, selects) here. -->
+    </div>
+
+    <div class="text-center">
+      <button type="button" id="generateBtn" class="px-6 py-2 bg-blue-600 dark:bg-blue-500 text-white rounded-md hover:bg-blue-700 dark:hover:bg-blue-600 transition-colors text-sm font-medium">Generate</button>
+    </div>
+
+    <div>
+      <label for="output" class="block font-bold text-lg mb-1 text-slate-700 dark:text-slate-200">Result</label>
+      <textarea id="output" rows="4" class="w-full p-3 border border-slate-300 dark:border-gray-600 rounded-md font-mono text-base resize-y bg-slate-50 dark:bg-gray-800 text-slate-900 dark:text-slate-100 focus:outline-none focus:ring-1 focus:ring-blue-500 transition-colors" readonly placeholder="Generated output will appear here..."></textarea>
+    </div>
+
+    <div class="text-center">
+      <button id="copyBtn" class="px-4 py-2 bg-slate-600 dark:bg-slate-500 hover:bg-slate-700 dark:hover:bg-slate-600 text-white rounded-md text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed transition-colors" disabled>Copy</button>
+    </div>
+
+${logSection}
+  </div>
+\`;
+
+class ${className} extends Tool {
+  constructor() {
+    super({
+      id: '${toolId}',
+      name: '${name}',
+      category: '${categoryId}',
+      needsFileUpload: false,
+      needsProcessButton: false,
+      hasOutput: true,
+      template
+    });
+  }
+
+  getElementsMap() {
+    return {
+      output: 'output',
+      generateBtn: 'generateBtn',
+      copyBtn: 'copyBtn',
+      logHeader: 'logHeader',
+      logContent: 'logContent'
+    };
+  }
+
+  async setup() {
+    this.elements.generateBtn?.addEventListener('click', () => this.generate());
+    this.elements.copyBtn?.addEventListener('click', () => this.copyOutput());
+    this.log('${name} ready', 'info');
+  }
+
+  generate() {
+    // TODO: implement generation (use crypto.getRandomValues / crypto.randomUUID for privacy-safe randomness).
+    const result = '';
+    this.elements.output.value = result;
+    this.elements.copyBtn.disabled = !result;
+    this.log('Generated.', 'success');
+  }
+
+  async copyOutput() {
+    const text = this.elements.output.value;
+    if (!text) return;
+    try {
+      await navigator.clipboard.writeText(text);
+      this.elements.copyBtn.textContent = 'Copied!';
+      setTimeout(() => { this.elements.copyBtn.textContent = 'Copy'; }, 1500);
+    } catch (error) {
+      this.log(\`Failed to copy: \${error.message}\`, 'error');
+    }
+  }
+}
+
+export function initTool() {
+  const tool = new ${className}();
+  return tool.init();
+}
+`;
+}
+
+const moduleBuilders = { file: fileModule, text: textModule, generator: generatorModule };
+
+// ---------------------------------------------------------------------------
+// Test stub per kind
+// ---------------------------------------------------------------------------
+function testStub() {
+  const elementChecks = {
+    file: ["    await expect(page.locator('#dropZone')).toBeVisible();", "    await expect(page.locator('#processBtn')).toBeAttached();"],
+    text: ["    await expect(page.locator('#inputText')).toBeVisible();", "    await expect(page.locator('#outputText')).toBeAttached();", "    await expect(page.locator('#processBtn')).toBeVisible();"],
+    generator: ["    await expect(page.locator('#generateBtn')).toBeVisible();", "    await expect(page.locator('#output')).toBeAttached();"]
+  }[kind].join('\n');
+
+  return `// @ts-check
+import { test, expect } from '@playwright/test';
+
+test.describe('${name}', () => {
+  test('renders and is interactive', async ({ page }) => {
+    await page.goto('/${categoryId}/${toolId}');
+    await expect(page.locator('.tool-container[data-tool-ready="true"]')).toBeVisible();
+${elementChecks}
+  });
+});
+`;
+}
+
+// ---------------------------------------------------------------------------
+// Metadata insertion
+// ---------------------------------------------------------------------------
+function metadataEntry() {
+  return `  '${toolPath}': {
     id: '${toolId}',
     category: '${categoryId}',
     name: '${name}',
-    description: '${description}',
+    description: '${description.replace(/'/g, "\\'")}',
     icon: '${icon}',
-    keywords: ['${toolId}', '${name.toLowerCase()}', '${categoryId} tool'],
+    keywords: ['${toolId}', '${name.toLowerCase().replace(/'/g, "\\'")}', '${categoryId} tool'],
     howToUse: [
-      'Select a file from your device',
-      'Choose any options needed for the output',
-      'Click "Process" and download or copy the result'
+      'Open the tool in your browser',
+      'Provide your input and choose any options',
+      'Get the result instantly — nothing is uploaded'
     ],
-    useCase: 'Use ${name} when you need a private, browser-local ${categoryId} workflow.'
-  },`);
-console.log(`\nThen run: npm run test:tool -- ${toolPath}`);
+    useCase: 'Use ${name.replace(/'/g, "\\'")} when you need a private, browser-local ${categoryId} workflow.'
+  },`;
+}
+
+function insertMetadata() {
+  const metadataPath = path.join(rootDir, 'src', 'common', 'metadata.js');
+  const source = readFileSync(metadataPath, 'utf8');
+
+  if (source.includes(`'${toolPath}':`)) {
+    return { inserted: false, reason: 'already present' };
+  }
+
+  const marker = 'export const tools = {';
+  const startIdx = source.indexOf(marker);
+  if (startIdx === -1) {
+    return { inserted: false, reason: 'could not find tools object' };
+  }
+
+  // The first line that is exactly "};" after the marker closes the tools object
+  // (nested entries close with an indented "},").
+  const closeIdx = source.indexOf('\n};', startIdx);
+  if (closeIdx === -1) {
+    return { inserted: false, reason: 'could not find end of tools object' };
+  }
+
+  // The previous entry may or may not have a trailing comma (the last one often
+  // doesn't). Ensure one before appending, unless the object is empty.
+  let before = source.slice(0, closeIdx).replace(/\s+$/, '');
+  if (!before.endsWith(',') && !before.endsWith('{')) {
+    before += ',';
+  }
+
+  const updated = `${before}\n${metadataEntry()}${source.slice(closeIdx)}`;
+  writeFileSync(metadataPath, updated);
+  return { inserted: true };
+}
+
+// ---------------------------------------------------------------------------
+// Write files
+// ---------------------------------------------------------------------------
+const categoryDir = path.join(rootDir, 'src', categoryId);
+const modulePath = path.join(categoryDir, `${toolId}.js`);
+
+if (existsSync(modulePath)) {
+  console.error(`Refusing to overwrite existing module: ${path.relative(rootDir, modulePath)}`);
+  process.exit(1);
+}
+
+mkdirSync(categoryDir, { recursive: true });
+writeFileSync(modulePath, moduleBuilders[kind]());
+console.log(`Created ${path.relative(rootDir, modulePath)} (kind: ${kind})`);
+
+// Metadata
+if (skipMetadata) {
+  console.log('\nSkipped metadata insertion (--no-metadata). Add this entry to src/common/metadata.js under tools:\n');
+  console.log(metadataEntry());
+} else {
+  const result = insertMetadata();
+  if (result.inserted) {
+    console.log('Inserted metadata entry into src/common/metadata.js');
+  } else {
+    console.log(`\nCould not auto-insert metadata (${result.reason}). Add this entry to src/common/metadata.js under tools:\n`);
+    console.log(metadataEntry());
+  }
+}
+
+// Test stub
+if (!skipTest) {
+  const testPath = path.join(rootDir, 'tests', `${categoryId}-${toolId}.spec.js`);
+  if (existsSync(testPath)) {
+    console.log(`Test already exists, leaving it untouched: ${path.relative(rootDir, testPath)}`);
+  } else {
+    writeFileSync(testPath, testStub());
+    console.log(`Created ${path.relative(rootDir, testPath)}`);
+  }
+}
+
+console.log(`\nNext:`);
+console.log(`  1. Implement the TODO in src/${toolPath}.js`);
+console.log(`  2. Refine the metadata (keywords, howToUse, useCase) in src/common/metadata.js`);
+console.log(`  3. Run: npm run test:tool -- ${toolPath}`);

--- a/src/common/page-renderers.js
+++ b/src/common/page-renderers.js
@@ -79,7 +79,15 @@ export function renderToolPageShell(toolInfo) {
           </div>
         </div>
         <div class="px-4 py-5 sm:p-6">
-          <div class="tool-content-area" data-agent-region="tool-ui"></div>
+          <div class="tool-content-area" data-agent-region="tool-ui">
+            <div data-tool-loading class="flex flex-col items-center justify-center gap-3 py-20 text-slate-400 dark:text-slate-500">
+              <svg class="h-8 w-8 animate-spin text-blue-500" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 0 1 8-8v4a4 4 0 0 0-4 4H4z"></path>
+              </svg>
+              <span class="text-sm font-medium">Loading tool…</span>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,6 @@
 import { handleRoute } from './router.js';
 import { categories, getToolEntries, getToolSearchText } from './common/metadata.js';
+import { loadToolModule, resolveAppRoute } from './common/tool-registry.js';
 import './styles/main.css';
 import './index.css';
 
@@ -157,6 +158,31 @@ function initToolShareButtons() {
   });
 }
 
+// Warm the tool chunk before the click so navigation feels instant.
+function initToolPrefetch() {
+  const prefetched = new Set();
+
+  const prefetch = (link) => {
+    const href = link?.getAttribute('href');
+    if (!href || !href.startsWith('/') || link.hostname !== window.location.hostname) return;
+
+    const route = resolveAppRoute(href);
+    if (route.kind !== 'tool' || prefetched.has(route.toolPath)) return;
+
+    prefetched.add(route.toolPath);
+    loadToolModule(route.categoryId, route.toolId).catch(() => prefetched.delete(route.toolPath));
+  };
+
+  const onHover = (event) => {
+    const link = event.target.closest?.('a');
+    if (link) prefetch(link);
+  };
+
+  document.addEventListener('mouseover', onHover);
+  document.addEventListener('focusin', onHover);
+  document.addEventListener('touchstart', onHover, { passive: true });
+}
+
 // Router functionality
 function initRouter() {
   // Handle initial page load
@@ -262,6 +288,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   renderNavigation();
   initRouter();
+  initToolPrefetch();
   initGlobalToolSearch();
   initInlineToolFilters();
   initToolShareButtons();

--- a/src/router.js
+++ b/src/router.js
@@ -11,10 +11,6 @@ import { loadToolModule, resolveAppRoute } from './common/tool-registry.js';
 
 let navigationToken = 0;
 
-function delay(ms) {
-  return new Promise(resolve => setTimeout(resolve, ms));
-}
-
 function isHomePath(path) {
   return path === '/' || path === '/home';
 }
@@ -96,14 +92,16 @@ function injectToolTemplate(moduleImport) {
 async function initializeToolRoute(route, main, tokenAtStart) {
   if (route.kind !== 'tool') return;
 
-  await delay(50);
-  if (tokenAtStart !== navigationToken) return;
-
   try {
     await import('./common/utils.js');
+    if (tokenAtStart !== navigationToken) return;
 
     if (route.categoryId === 'video') {
-      document.querySelector('.tool-content-area')?.appendChild(createFFmpegLoadingElement());
+      const area = document.querySelector('.tool-content-area');
+      if (area) {
+        area.innerHTML = '';
+        area.appendChild(createFFmpegLoadingElement());
+      }
     }
 
     let moduleImport;

--- a/vite.config.js
+++ b/vite.config.js
@@ -21,8 +21,9 @@ export default defineConfig({
         // Preserve source directory structure for tool files
         entryFileNames: (chunkInfo) => {
           const id = chunkInfo.facadeModuleId || '';
-          // Match tool paths and preserve their structure
-          if (id.match(/\/src\/(video|image|text)\/[a-z-]+\.js$/)) {
+          // Preserve the structure of any category tool module (not shared/common).
+          // Matches any src/<category>/<toolId>.js, including digit-containing ids like ml/image2text.
+          if (id.match(/\/src\/(?!common\/)[a-z0-9-]+\/[a-z0-9-]+\.js$/)) {
             // Preserve the full path including src
             const path = id.includes('/src/') ? id.split('/src/')[1] : id;
             return `src/${path}`;


### PR DESCRIPTION
## What
Makes adding a tool frictionless, fixes the navigation delay/blank-box on tile clicks, and patches a high-severity esbuild security advisory.

## Changes

### Extensibility scaffold (c64f82e)
- **scripts/scaffold-tool.mjs**: `--kind=file|text|generator` templates; auto-inserts the metadata entry into `metadata.js`; generates a kind-aware Playwright smoke test. Opt-outs: `--no-metadata`, `--no-test`.
- **vite.config.js**: `entryFileNames` now preserves any category dir and digit-containing tool ids (fixes `ml/` and `time/`, e.g. `ml/image2text` which the old `[a-z-]+` silently dropped).
- **netlify.toml**: add JS header rules for `/ml/` and `/time/` chunks to match the new output paths.
- **CLAUDE.md**: document the new scaffold workflow.
- **documentation/improvement-plan.md**: keep Google Analytics as-is (reconcile on-page wording instead of removing), add a Priority 0 extensibility section.

### Navigation fix (1a0e5c3)
- **router.js**: removed the artificial 50ms delay before loading a tool module; show the FFmpeg loading element immediately for video tools.
- **page-renderers.js**: tool page shell now renders a spinner + "Loading..." instead of a blank box, and prefetches tool modules on tile hover.

### Security fix (3e8c4da)
- **package.json / package-lock.json**: upgrade `vite` `^5.1.4` → `^6.4.3`, bumping bundled `esbuild` `0.21.5` → `0.25.12`. Resolves the GitHub security advisory **GHSA-67mh-4wv8-2f99** (esbuild dev server allows any website to send requests and read responses).
- Remaining `npm audit` finding (`GHSA-gv7w-rqvm-qjhr`) is Deno-specific and not applicable to this Node/npm project; fixing it would require a vite 8 major bump, deferred.

### Doc clarification (80d9fef)
- **CLAUDE.md**: narrowed Cardinal Rule #2 — tool *processing logic* must never call analytics/tracking, but the existing anonymous, page-view-only Google Analytics (`src/main.js`, gated off localhost) is intentional and must be preserved.

## Verification
- `npm run test:contract` passes (24 tools, 5 categories)
- `npm run build` succeeds on vite 6
- `npm run verify:full`: 200 passed, 2 skipped, 2 failed (pre-existing WebM re-encode FFmpeg-WASM flake, reproduced identically on vite 5 — unrelated to this PR)
- Scaffolded and removed a throwaway `text/dummy-check` tool end-to-end (auto-metadata, generated test, contract + smoke tests passing) with zero router edits
- Deploy preview spot-checked: homepage, instant tile-click navigation (no blank box), JSON Formatter, Image Compressor full compress flow — no console errors, GA (`G-SK7DDP7ND6`) loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
